### PR TITLE
feat(downstream-repo): add cross-repo sync workflows with explicit content-based detection for downstream repos

### DIFF
--- a/.github/scripts/sync-brew-formula.py
+++ b/.github/scripts/sync-brew-formula.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Smart-merge two Homebrew formula files, protecting version/url/sha256 in the target.
+
+Reads a SOURCE formula (from the main repo's homebrew-tap/) and a TARGET formula
+(from the subsidiary tap repo checkout), then writes a merged version to the
+target path. Protected fields (version, url, sha256) are kept from the target;
+all other lines come from the source.
+
+Usage:
+    python3 .github/scripts/sync-brew-formula.py <source_path> <target_path>
+
+Exit codes:
+    0   Success — merged formula written to target path (silent)
+    1   Error — message printed to stderr
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Matches indented Homebrew formula lines like:
+#   version "1.0.3"
+#   url "https://..."
+#   sha256 "abc123..."
+PROTECTED_RE = re.compile(r'^\s+(version|url|sha256)\s+"')
+
+
+def _read_lines(path: Path, *, required: bool = False) -> list[str]:
+    """Read file lines, preserving line endings.
+
+    Args:
+        path: Path to the file to read.
+        required: If True, exit with error when the file cannot be read.
+
+    Returns:
+        List of lines with line endings preserved.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        if required:
+            print(f"::error::Required file not found: '{path}'", file=sys.stderr)
+            sys.exit(1)
+        return []
+    except OSError as exc:
+        print(f"::error::Failed to read '{path}': {exc}", file=sys.stderr)
+        if required:
+            sys.exit(1)
+        return []
+    return text.splitlines(keepends=True)
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    """Write a list of lines to the target path, preserving line endings."""
+    try:
+        path.write_text("".join(lines), encoding="utf-8")
+    except OSError as exc:
+        print(f"::error::Failed to write '{path}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _collect_protected(lines: list[str]) -> dict[str, list[str]]:
+    """Collect protected lines (version, url, sha256) from a formula.
+
+    Returns a dict mapping each field name to its lines in declaration order.
+    """
+    collected: dict[str, list[str]] = {"version": [], "url": [], "sha256": []}
+    for line in lines:
+        m = PROTECTED_RE.match(line)
+        if m:
+            field = m.group(1)
+            collected[field].append(line)
+    return collected
+
+
+def merge_formulas(source_lines: list[str], target_lines: list[str]) -> list[str]:
+    """Merge source and target formula lines, protecting target's version/url/sha256.
+
+    For each protected field, the corresponding line(s) from *target* are emitted
+    in place of the source line. If the target has fewer lines for a field than
+    the source, the source line is used as a fallback.
+
+    Args:
+        source_lines: Lines from the source formula (monorepo).
+        target_lines: Lines from the target formula (tap repo).
+
+    Returns:
+        Merged lines ready to write to the target path.
+    """
+    if not target_lines:
+        return list(source_lines)
+
+    target_protected = _collect_protected(target_lines)
+    consumed: dict[str, int] = {"version": 0, "url": 0, "sha256": 0}
+
+    result: list[str] = []
+    for line in source_lines:
+        m = PROTECTED_RE.match(line)
+        if m:
+            field = m.group(1)
+            target_list = target_protected[field]
+            idx = consumed[field]
+            if idx < len(target_list):
+                result.append(target_list[idx])
+                consumed[field] = idx + 1
+            else:
+                # Target has fewer entries than source — fall back to source line
+                result.append(line)
+        else:
+            result.append(line)
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Smart-merge two Homebrew formula files, protecting version/url/sha256 in the target.",
+    )
+    parser.add_argument("source_path", type=str, help="Path to the source formula (monorepo)")
+    parser.add_argument("target_path", type=str, help="Path to the target formula (tap repo)")
+    args = parser.parse_args()
+
+    source_path = Path(args.source_path)
+    target_path = Path(args.target_path)
+
+    source_lines = _read_lines(source_path, required=True)
+    target_lines = _read_lines(target_path)
+
+    merged = merge_formulas(source_lines, target_lines)
+    _write_lines(target_path, merged)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/sync-brew-formula.py
+++ b/.github/scripts/sync-brew-formula.py
@@ -9,6 +9,7 @@ all other lines come from the source.
 
 Usage:
     python3 .github/scripts/sync-brew-formula.py <source_path> <target_path>
+    python3 .github/scripts/sync-brew-formula.py <source_path> <target_path> --output <output_path>
 
 Exit codes:
     0   Success — merged formula written to target path (silent)
@@ -119,7 +120,18 @@ def main() -> int:
         description="Smart-merge two Homebrew formula files, protecting version/url/sha256 in the target.",
     )
     parser.add_argument("source_path", type=str, help="Path to the source formula (monorepo)")
-    parser.add_argument("target_path", type=str, help="Path to the target formula (tap repo)")
+    parser.add_argument(
+        "target_path",
+        type=str,
+        help="Target formula file. Reads the current state for comparison. "
+        "If --output is not provided, the merged result overwrites this file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path for merged formula. Defaults to overwriting target.",
+    )
     args = parser.parse_args()
 
     source_path = Path(args.source_path)
@@ -129,7 +141,8 @@ def main() -> int:
     target_lines = _read_lines(target_path)
 
     merged = merge_formulas(source_lines, target_lines)
-    _write_lines(target_path, merged)
+    output_path = Path(args.output) if args.output else target_path
+    _write_lines(output_path, merged)
 
     return 0
 

--- a/.github/workflows/sync-github-action.yml
+++ b/.github/workflows/sync-github-action.yml
@@ -3,12 +3,14 @@
 #
 # Sync GitHub Action
 # ──────────────────────────────────────────────────────────────────────────────
-# Trigger: Any push to main that touches files under github-action/
+# Triggers: Push to main/develop touching github-action/ files, manual dispatch, or weekly schedule.
 #
 # What it does:
 #   1. Clones the subsidiary action repo (divisionseven/pkg-defender-action)
-#   2. Rsyncs the github-action/ directory from THIS repo into the action repo
-#   3. Creates a sync PR in the action repo (closes any prior stale sync PRs)
+#   2. Compares github-action/ tree against downstream using diff -rq
+#   3. If differences found, rsyncs the github-action/ directory into the action repo
+#   4. Verifies changes were applied correctly
+#   5. Creates a sync PR in the action repo (closes any prior stale sync PRs)
 #
 # The --delete flag in rsync is intentional — if a file is removed from
 # github-action/ in the monorepo, it is removed from the action repo too.
@@ -24,6 +26,9 @@ on:
     branches: [main, develop]
     paths:
       - "github-action/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -52,10 +57,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      # ── Step 2: Set target repo — defined as env at job level ───────────────
-      # (ACTION_REPO is set in the job's env block above.)
-
-      # ── Step 3: Clone action repo ───────────────────────────────────────────
+      # ── Step 2: Clone action repo ───────────────────────────────────────────
       # Uses the ACTION_REPO_PAT for authentication. This PAT must have
       # 'Contents: write' and 'Pull requests: write' on the target repo.
       - name: Clone action repository
@@ -78,10 +80,46 @@ jobs:
           }
           echo "Action repo cloned successfully to /tmp/action-repo"
 
+      # ── Step 3: Compare files against downstream repo ──────────────────────
+      # Uses diff -rq for content-based comparison BEFORE any files are copied.
+      # This is a pure read-only check with no side effects.
+      #
+      # Exclusions must match the rsync step below:
+      #   node_modules              — installed dependencies, not committed to source
+      #   plans                     — internal planning documents
+      #   internal_documentation    — internal agent documentation
+      #   .DS_Store                 — macOS metadata file
+      #
+      # diff -x uses shell glob patterns (basename match at any depth).
+      # The || true suppresses diff's exit code (diff exits 1 when files differ).
+      - name: Compare files against downstream repo
+        id: compare
+        run: |
+          DIFF_OUTPUT=$(diff -rq \
+            "${{ github.workspace }}/github-action/" \
+            /tmp/action-repo/ \
+            -x 'node_modules' \
+            -x 'plans' \
+            -x 'internal_documentation' \
+            -x '.DS_Store' \
+            2>/dev/null || true)
+
+          if [ -z "$DIFF_OUTPUT" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "✅ All files match downstream — nothing to sync."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "⛁ Content differences detected:"
+            echo "$DIFF_OUTPUT"
+          fi
+
       # ── Step 4: Sync files from github-action/ to action repo ──────────────
       # Uses rsync with --delete so files removed from the source are also
       # removed from the target. The trailing slash on github-action/ means
       # we copy the CONTENTS of the directory, not the directory itself.
+      #
+      # The .gitignore is intentionally synced from source — the action repo's
+      # .gitignore is managed from the monorepo.
       #
       # Exclusions:
       #   node_modules/              — installed dependencies, not committed to source
@@ -90,8 +128,9 @@ jobs:
       #   .DS_Store                  — macOS metadata file
       #
       # The dist/ directory IS synced (it's part of the action repo's committed
-      # source). The .gitignore is also synced from source intentionally.
+      # source).
       - name: Sync files with rsync
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           echo "Syncing github-action/ to /tmp/action-repo/..."
           rsync -av --delete \
@@ -104,43 +143,37 @@ jobs:
           echo ""
           echo "Sync complete."
 
-      # ── Step 5: .gitignore handling ─────────────────────────────────────────
-      # No restore step needed — the .gitignore is intentionally synced from
-      # source. The action repo's .gitignore is managed from the monorepo.
-
-      # ── Step 6: Check for changes ──────────────────────────────────────────
-      # If there are no changes after the rsync, we skip creating a PR.
-      # This avoids unnecessary noise when non-functional changes (like
-      # whitespace-only edits) don't produce meaningful diffs.
-      - name: Check for changes
-        id: check-changes
+      # ── Step 5: Verify changes were applied ────────────────────────────────
+      # Safety-net verification that the rsync actually produced content changes.
+      # A warning is emitted if rsync ran but git status shows no changes —
+      # this can happen with permission-only differences.
+      - name: Verify changes were applied
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/action-repo
           if [ -z "$(git status --porcelain)" ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "✓ No changes to sync."
+            echo "::warning::Rsync ran but no content changes detected. Possible permission-only differences."
           else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected:"
+            echo "✅ Changes verified: $(git status --porcelain | wc -l) file(s) modified"
             git status --short
           fi
 
-      # ── Step 7: Configure git identity ──────────────────────────────────────
+      # ── Step 6: Configure git identity ──────────────────────────────────────
       # Only needed when there are changes to commit. Uses the standard
       # github-actions[bot] identity used across all project workflows.
       - name: Configure git identity
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/action-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # ── Step 8: Create sync branch ─────────────────────────────────────────
+      # ── Step 7: Create sync branch ─────────────────────────────────────────
       # Branch name includes the date and short commit SHA for traceability
       # back to the triggering commit in the monorepo.
       - name: Create sync branch
         id: create-branch
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/action-repo
           BRANCH="sync/action-$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
@@ -148,13 +181,13 @@ jobs:
           echo "Created branch: ${BRANCH}"
           echo "branch-name=${BRANCH}" >> "$GITHUB_OUTPUT"
 
-      # ── Step 9: Stage and commit ────────────────────────────────────────────
+      # ── Step 8: Stage and commit ────────────────────────────────────────────
       # Commit message references the triggering commit URL for full audit
       # trail. Uses `git add -A` to handle renames and deletions correctly.
       # Uses two -m arguments to produce a conventional commit with a blank
       # line separating the subject from the body.
       - name: Commit changes
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/action-repo
           git add -A
@@ -162,17 +195,17 @@ jobs:
             -m "chore: sync github-action from pkg-defender" \
             -m "Triggered by ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
 
-      # ── Step 10: Push branch ───────────────────────────────────────────────
+      # ── Step 9: Push sync branch ───────────────────────────────────────────
       # Pushes the sync branch to the action repo so a PR can be created.
       # The remote URL already has the PAT embedded from the git clone step.
       - name: Push sync branch
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/action-repo
           git push origin "${{ steps.create-branch.outputs.branch-name }}"
           echo "✓ Pushed branch: ${{ steps.create-branch.outputs.branch-name }}"
 
-      # ── Step 11: Close stale sync PRs ──────────────────────────────────────
+      # ── Step 10: Close stale sync PRs ──────────────────────────────────────
       # Unconditional — always runs, even if there are no new changes.
       # Closes any open PRs in the action repo whose head branch starts
       # with "sync/action-" to prevent merge conflicts between overlapping
@@ -203,12 +236,12 @@ jobs:
             done
           fi
 
-      # ── Step 12: Create PR in action repo ──────────────────────────────────
+      # ── Step 11: Create pull request in action repo ────────────────────────
       # Only runs when there are actual changes to sync. Builds a summary
       # of changed files from the git diff and creates a PR targeting main.
       - name: Create pull request
         id: create-pr
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.ACTION_REPO_PAT }}
         run: |

--- a/.github/workflows/sync-github-action.yml
+++ b/.github/workflows/sync-github-action.yml
@@ -1,0 +1,247 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# .github/workflows/sync-github-action.yml
+#
+# Sync GitHub Action
+# ──────────────────────────────────────────────────────────────────────────────
+# Trigger: Any push to main that touches files under github-action/
+#
+# What it does:
+#   1. Clones the subsidiary action repo (divisionseven/pkg-defender-action)
+#   2. Rsyncs the github-action/ directory from THIS repo into the action repo
+#   3. Creates a sync PR in the action repo (closes any prior stale sync PRs)
+#
+# The --delete flag in rsync is intentional — if a file is removed from
+# github-action/ in the monorepo, it is removed from the action repo too.
+# The source path is github-action/ (with trailing slash) so only the
+# CONTENTS of the directory are synced, not the directory itself.
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: 🔄 Sync GitHub Action
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "github-action/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# ── PROJECT VARIABLES ─────────────────────────────────────────────────────────
+env:
+  ACTION_REPO: divisionseven/pkg-defender-action
+
+# ──────────────────────────────────────────────────────────────────────────────
+jobs:
+  sync-action:
+    name: Sync GitHub Action
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── Step 1: Checkout source repo ────────────────────────────────────────
+      # Shallow checkout — we only need the latest commit to get the current
+      # state of github-action/. Full history is not needed for a file sync.
+      - name: Checkout source repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      # ── Step 2: Set target repo — defined as env at job level ───────────────
+      # (ACTION_REPO is set in the job's env block above.)
+
+      # ── Step 3: Clone action repo ───────────────────────────────────────────
+      # Uses the ACTION_REPO_PAT for authentication. This PAT must have
+      # 'Contents: write' and 'Pull requests: write' on the target repo.
+      - name: Clone action repository
+        env:
+          ACTION_REPO_PAT: ${{ secrets.ACTION_REPO_PAT }}
+        run: |
+          echo "Cloning ${ACTION_REPO}..."
+          git clone "https://${ACTION_REPO_PAT}@github.com/${ACTION_REPO}.git" /tmp/action-repo || {
+            echo "FAIL: Could not clone action repo ${ACTION_REPO}"
+            echo ""
+            echo "Possible causes:"
+            echo "  1. Repository does not exist — create divisionseven/pkg-defender-action first"
+            echo "  2. ACTION_REPO_PAT is invalid or expired — generate a new one in GitHub settings"
+            echo "  3. ACTION_REPO_PAT is missing required permissions — needs 'Contents: write' and"
+            echo "     'Pull requests: write' on ${ACTION_REPO}"
+            echo ""
+            echo "Verify at: https://github.com/${ACTION_REPO}"
+            echo "PAT settings: https://github.com/settings/personal-access-tokens"
+            exit 1
+          }
+          echo "Action repo cloned successfully to /tmp/action-repo"
+
+      # ── Step 4: Sync files from github-action/ to action repo ──────────────
+      # Uses rsync with --delete so files removed from the source are also
+      # removed from the target. The trailing slash on github-action/ means
+      # we copy the CONTENTS of the directory, not the directory itself.
+      #
+      # Exclusions:
+      #   node_modules/              — installed dependencies, not committed to source
+      #   plans/                     — internal planning documents, not part of the action
+      #   internal_documentation/    — internal agent documentation, not part of the action
+      #   .DS_Store                  — macOS metadata file
+      #
+      # The dist/ directory IS synced (it's part of the action repo's committed
+      # source). The .gitignore is also synced from source intentionally.
+      - name: Sync files with rsync
+        run: |
+          echo "Syncing github-action/ to /tmp/action-repo/..."
+          rsync -av --delete \
+            --exclude='node_modules/' \
+            --exclude='plans/' \
+            --exclude='internal_documentation/' \
+            --exclude='.DS_Store' \
+            github-action/ \
+            /tmp/action-repo/
+          echo ""
+          echo "Sync complete."
+
+      # ── Step 5: .gitignore handling ─────────────────────────────────────────
+      # No restore step needed — the .gitignore is intentionally synced from
+      # source. The action repo's .gitignore is managed from the monorepo.
+
+      # ── Step 6: Check for changes ──────────────────────────────────────────
+      # If there are no changes after the rsync, we skip creating a PR.
+      # This avoids unnecessary noise when non-functional changes (like
+      # whitespace-only edits) don't produce meaningful diffs.
+      - name: Check for changes
+        id: check-changes
+        run: |
+          cd /tmp/action-repo
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "✓ No changes to sync."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected:"
+            git status --short
+          fi
+
+      # ── Step 7: Configure git identity ──────────────────────────────────────
+      # Only needed when there are changes to commit. Uses the standard
+      # github-actions[bot] identity used across all project workflows.
+      - name: Configure git identity
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/action-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # ── Step 8: Create sync branch ─────────────────────────────────────────
+      # Branch name includes the date and short commit SHA for traceability
+      # back to the triggering commit in the monorepo.
+      - name: Create sync branch
+        id: create-branch
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/action-repo
+          BRANCH="sync/action-$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
+          git checkout -b "${BRANCH}"
+          echo "Created branch: ${BRANCH}"
+          echo "branch-name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      # ── Step 9: Stage and commit ────────────────────────────────────────────
+      # Commit message references the triggering commit URL for full audit
+      # trail. Uses `git add -A` to handle renames and deletions correctly.
+      # Uses two -m arguments to produce a conventional commit with a blank
+      # line separating the subject from the body.
+      - name: Commit changes
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/action-repo
+          git add -A
+          git commit \
+            -m "chore: sync github-action from pkg-defender" \
+            -m "Triggered by ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+
+      # ── Step 10: Push branch ───────────────────────────────────────────────
+      # Pushes the sync branch to the action repo so a PR can be created.
+      # The remote URL already has the PAT embedded from the git clone step.
+      - name: Push sync branch
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/action-repo
+          git push origin "${{ steps.create-branch.outputs.branch-name }}"
+          echo "✓ Pushed branch: ${{ steps.create-branch.outputs.branch-name }}"
+
+      # ── Step 11: Close stale sync PRs ──────────────────────────────────────
+      # Unconditional — always runs, even if there are no new changes.
+      # Closes any open PRs in the action repo whose head branch starts
+      # with "sync/action-" to prevent merge conflicts between overlapping
+      # syncs. Uses GH_TOKEN for authentication.
+      - name: Close stale sync PRs
+        env:
+          GH_TOKEN: ${{ secrets.ACTION_REPO_PAT }}
+        run: |
+          echo "Checking for stale action sync PRs..."
+          echo ""
+
+          STALE_PRS=$(gh pr list \
+            --repo "${ACTION_REPO}" \
+            --state open \
+            --json headRefName,url \
+            --jq '.[] | select(.headRefName | startswith("sync/action-")) | .url')
+
+          if [ -z "${STALE_PRS}" ]; then
+            echo "✓ No stale action sync PRs found."
+          else
+            echo "Found stale PR(s):"
+            for pr_url in ${STALE_PRS}; do
+              echo "  Closing: ${pr_url}"
+              gh pr close "${pr_url}" \
+                --repo "${ACTION_REPO}" \
+                --comment "Superseded by newer sync."
+              echo "  ✓ Closed: ${pr_url}"
+            done
+          fi
+
+      # ── Step 12: Create PR in action repo ──────────────────────────────────
+      # Only runs when there are actual changes to sync. Builds a summary
+      # of changed files from the git diff and creates a PR targeting main.
+      - name: Create pull request
+        id: create-pr
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ACTION_REPO_PAT }}
+        run: |
+          cd /tmp/action-repo
+
+          # Build a summary of changed files
+          SUMMARY=$(git diff --name-status main..."${{ steps.create-branch.outputs.branch-name }}" 2>/dev/null || echo "Unknown changes")
+
+          # Create the PR and capture its URL
+          PR_URL=$(gh pr create \
+            --repo "${ACTION_REPO}" \
+            --title "Sync GitHub Action — $(date +%Y-%m-%d)" \
+            --body "## What
+
+          Syncs \`github-action/\` from \`divisionseven/pkg-defender\` to this action repository.
+
+          ## Changes
+
+          \`\`\`
+          ${SUMMARY}
+          \`\`\`
+
+          ## Note
+
+          This is a full directory sync. Files removed from the source will also be removed here.
+
+          Auto-generated by the [sync-github-action](${{ github.server_url }}/${{ github.repository }}/actions/workflows/sync-github-action.yml) workflow.
+          " \
+            --head "${{ steps.create-branch.outputs.branch-name }}" \
+            --base "main")
+
+          # Extract PR number from URL
+          PR_NUMBER="${PR_URL##*/}"
+          echo "pull-request-number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo ""
+          echo "✓ Created PR #${PR_NUMBER}: ${PR_URL}"

--- a/.github/workflows/sync-homebrew-tap.yml
+++ b/.github/workflows/sync-homebrew-tap.yml
@@ -5,7 +5,7 @@
 # homebrew-tap/ directory to the subsidiary tap repository
 # (divisionseven/homebrew-pkg-defender).
 #
-# Trigger: Push to main that touches any file under homebrew-tap/.
+# Triggers: Push to main/develop touching homebrew-tap/ files, manual dispatch, or weekly schedule.
 #
 # What it syncs:
 #   • README.md
@@ -17,6 +17,9 @@
 # The formula merge uses sync-brew-formula.py to protect the tap repo's
 # current version, download URLs, and SHA256 checksums so the release
 # pipeline retains sole ownership of those values.
+#
+# Sync detection uses per-file diff -q comparison (not git status) to
+# accurately detect content changes before any files are copied.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: 🔄 Sync Homebrew Tap
@@ -26,6 +29,9 @@ on:
     branches: [main, develop]
     paths:
       - "homebrew-tap/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,8 +78,77 @@ jobs:
           echo "Tap repo cloned successfully to /tmp/tap-repo"
           ls -la /tmp/tap-repo/
 
-      # ── 3. Sync source-of-truth files ──────────────────────────────────────
+      # ── 3. Compare files against downstream repo ──────────────────────────
+      - name: Compare files against downstream repo
+        id: compare
+        run: |
+          cd /tmp/tap-repo
+          MISMATCHES=""
+
+          # 1. README.md
+          if ! diff -q "${{ github.workspace }}/homebrew-tap/README.md" "README.md" > /dev/null 2>&1; then
+            echo "❌ README.md: content differs from downstream"
+            MISMATCHES="$MISMATCHES README.md"
+          else
+            echo "✅ README.md: matches downstream"
+          fi
+
+          # 2. LICENSE
+          if ! diff -q "${{ github.workspace }}/homebrew-tap/LICENSE" "LICENSE" > /dev/null 2>&1; then
+            echo "❌ LICENSE: content differs from downstream"
+            MISMATCHES="$MISMATCHES LICENSE"
+          else
+            echo "✅ LICENSE: matches downstream"
+          fi
+
+          # 3. .gitignore
+          if ! diff -q "${{ github.workspace }}/homebrew-tap/.gitignore" ".gitignore" > /dev/null 2>&1; then
+            echo "❌ .gitignore: content differs from downstream"
+            MISMATCHES="$MISMATCHES .gitignore"
+          else
+            echo "✅ .gitignore: matches downstream"
+          fi
+
+          # 4. .github/workflows/tests.yml
+          mkdir -p .github/workflows
+          if [ -f ".github/workflows/tests.yml" ]; then
+            if ! diff -q "${{ github.workspace }}/homebrew-tap/.github/workflows/tests.yml" ".github/workflows/tests.yml" > /dev/null 2>&1; then
+              echo "❌ .github/workflows/tests.yml: content differs from downstream"
+              MISMATCHES="$MISMATCHES .github/workflows/tests.yml"
+            else
+              echo "✅ .github/workflows/tests.yml: matches downstream"
+            fi
+          else
+            echo "❌ .github/workflows/tests.yml: new file (doesn't exist in downstream)"
+            MISMATCHES="$MISMATCHES .github/workflows/tests.yml"
+          fi
+
+          # 5. Formula/pkg-defender.rb — smart compare using the script with --output
+          python3 ${{ github.workspace }}/.github/scripts/sync-brew-formula.py \
+            "${{ github.workspace }}/homebrew-tap/Formula/pkg-defender.rb" \
+            "/tmp/tap-repo/Formula/pkg-defender.rb" \
+            --output /tmp/merged-formula.rb
+
+          if ! diff -q /tmp/merged-formula.rb "/tmp/tap-repo/Formula/pkg-defender.rb" > /dev/null 2>&1; then
+            echo "❌ Formula/pkg-defender.rb: structural changes differ (version/url/sha256 preserved)"
+            MISMATCHES="$MISMATCHES Formula/pkg-defender.rb"
+          else
+            echo "✅ Formula/pkg-defender.rb: matches downstream (no structural changes)"
+          fi
+
+          # Output results
+          if [ -z "$MISMATCHES" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "✓ All files match downstream — nothing to sync."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "changed_files=${MISMATCHES}" >> "$GITHUB_OUTPUT"
+            echo "⛁ Files to sync:$MISMATCHES"
+          fi
+
+      # ── 4. Sync source-of-truth files (only if changes) ────────────────────
       - name: Sync source-of-truth files
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           echo "Syncing README.md..."
           cp "${{ github.workspace }}/homebrew-tap/README.md" /tmp/tap-repo/README.md
@@ -90,30 +165,17 @@ jobs:
 
           echo "All source-of-truth files synced."
 
-      # ── 4. Smart-merge the formula ─────────────────────────────────────────
+      # ── 5. Smart-merge the formula (only if changes) ───────────────────────
       - name: Smart-merge formula (preserve version/url/sha256)
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           python3 "${{ github.workspace }}/.github/scripts/sync-brew-formula.py" \
             "${{ github.workspace }}/homebrew-tap/Formula/pkg-defender.rb" \
             "/tmp/tap-repo/Formula/pkg-defender.rb"
 
-      # ── 5. Check for changes ───────────────────────────────────────────────
-      - name: Check for changes
-        id: check-changes
-        run: |
-          cd /tmp/tap-repo
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "✓ No changes to sync."
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected:"
-            git status --short
-          fi
-
       # ── 6. Git config (only if changes) ────────────────────────────────────
       - name: Git config
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/tap-repo
           git config user.name "github-actions[bot]"
@@ -122,7 +184,7 @@ jobs:
       # ── 7. Create branch (only if changes) ─────────────────────────────────
       - name: Create branch
         id: create-branch
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/tap-repo
           BRANCH="sync/tap-$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
@@ -132,7 +194,7 @@ jobs:
 
       # ── 8. Commit changes (only if changes) ────────────────────────────────
       - name: Commit changes
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         run: |
           cd /tmp/tap-repo
           git add -A
@@ -142,7 +204,7 @@ jobs:
 
       # ── 9. Push branch (only if changes) ───────────────────────────────────
       - name: Push branch
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         env:
           HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
         run: |
@@ -178,7 +240,7 @@ jobs:
       # ── 11. Create pull request (only if changes) ──────────────────────────
       - name: Create pull request
         id: create-pr
-        if: steps.check-changes.outputs.has_changes == 'true'
+        if: steps.compare.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
         run: |

--- a/.github/workflows/sync-homebrew-tap.yml
+++ b/.github/workflows/sync-homebrew-tap.yml
@@ -1,0 +1,216 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# .github/workflows/sync-homebrew-tap.yml
+#
+# Homebrew Tap Sync — propagates structural changes from the monorepo's
+# homebrew-tap/ directory to the subsidiary tap repository
+# (divisionseven/homebrew-pkg-defender).
+#
+# Trigger: Push to main that touches any file under homebrew-tap/.
+#
+# What it syncs:
+#   • README.md
+#   • LICENSE
+#   • .gitignore
+#   • .github/workflows/tests.yml
+#   • Formula/pkg-defender.rb  (smart-merged — preserves version/url/sha256)
+#
+# The formula merge uses sync-brew-formula.py to protect the tap repo's
+# current version, download URLs, and SHA256 checksums so the release
+# pipeline retains sole ownership of those values.
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: 🔄 Sync Homebrew Tap
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "homebrew-tap/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# ──────────────────────────────────────────────────────────────────────────────
+jobs:
+  sync-tap:
+    name: Sync to divisionseven/homebrew-pkg-defender
+    runs-on: ubuntu-latest
+
+    env:
+      TAP_REPO: "divisionseven/homebrew-pkg-defender"
+
+    steps:
+      # ── 1. Checkout source repo ─────────────────────────────────────────────
+      - name: Checkout source repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      # ── 2. Clone tap repository ────────────────────────────────────────────
+      - name: Clone tap repository
+        env:
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          echo "Cloning ${TAP_REPO}..."
+          git clone "https://${HOMEBREW_TAP_PAT}@github.com/${TAP_REPO}.git" /tmp/tap-repo || {
+            echo "FAIL: Could not clone tap repo ${TAP_REPO}"
+            echo ""
+            echo "Possible causes:"
+            echo "  1. Repository does not exist — create it first"
+            echo "  2. PAT is invalid or expired — generate a new one"
+            echo "  3. PAT is missing required permissions — needs 'Contents: write' and 'Pull requests: write' on ${TAP_REPO}"
+            echo ""
+            echo "Verify at: https://github.com/${TAP_REPO}"
+            echo "PAT settings: https://github.com/settings/personal-access-tokens"
+            exit 1
+          }
+          echo "Tap repo cloned successfully to /tmp/tap-repo"
+          ls -la /tmp/tap-repo/
+
+      # ── 3. Sync source-of-truth files ──────────────────────────────────────
+      - name: Sync source-of-truth files
+        run: |
+          echo "Syncing README.md..."
+          cp "${{ github.workspace }}/homebrew-tap/README.md" /tmp/tap-repo/README.md
+
+          echo "Syncing LICENSE..."
+          cp "${{ github.workspace }}/homebrew-tap/LICENSE" /tmp/tap-repo/LICENSE
+
+          echo "Syncing .gitignore..."
+          cp "${{ github.workspace }}/homebrew-tap/.gitignore" /tmp/tap-repo/.gitignore
+
+          echo "Syncing tests.yml..."
+          mkdir -p /tmp/tap-repo/.github/workflows
+          cp "${{ github.workspace }}/homebrew-tap/.github/workflows/tests.yml" /tmp/tap-repo/.github/workflows/tests.yml
+
+          echo "All source-of-truth files synced."
+
+      # ── 4. Smart-merge the formula ─────────────────────────────────────────
+      - name: Smart-merge formula (preserve version/url/sha256)
+        run: |
+          python3 "${{ github.workspace }}/.github/scripts/sync-brew-formula.py" \
+            "${{ github.workspace }}/homebrew-tap/Formula/pkg-defender.rb" \
+            "/tmp/tap-repo/Formula/pkg-defender.rb"
+
+      # ── 5. Check for changes ───────────────────────────────────────────────
+      - name: Check for changes
+        id: check-changes
+        run: |
+          cd /tmp/tap-repo
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "✓ No changes to sync."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changes detected:"
+            git status --short
+          fi
+
+      # ── 6. Git config (only if changes) ────────────────────────────────────
+      - name: Git config
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/tap-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # ── 7. Create branch (only if changes) ─────────────────────────────────
+      - name: Create branch
+        id: create-branch
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/tap-repo
+          BRANCH="sync/tap-$(date +%Y%m%d)-${GITHUB_SHA:0:7}"
+          git checkout -b "${BRANCH}"
+          echo "Created branch: ${BRANCH}"
+          echo "branch-name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      # ── 8. Commit changes (only if changes) ────────────────────────────────
+      - name: Commit changes
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          cd /tmp/tap-repo
+          git add -A
+          git commit -m "chore: sync homebrew-tap from pkg-defender
+
+          Triggered by ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+
+      # ── 9. Push branch (only if changes) ───────────────────────────────────
+      - name: Push branch
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          cd /tmp/tap-repo
+          git push origin "${{ steps.create-branch.outputs.branch-name }}"
+
+      # ── 10. Close stale sync PRs (unconditional) ───────────────────────────
+      - name: Close stale sync PRs
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          cd /tmp/tap-repo
+
+          STALE_PRS=$(gh pr list \
+            --repo "${TAP_REPO}" \
+            --state open \
+            --json headRefName,url \
+            --jq '.[] | select(.headRefName | startswith("sync/tap-")) | .url')
+
+          if [ -z "${STALE_PRS}" ]; then
+            echo "✓ No stale tap sync PRs found."
+          else
+            echo "Found stale PR(s):"
+            for pr_url in ${STALE_PRS}; do
+              echo "  Closing: ${pr_url}"
+              gh pr close "${pr_url}" \
+                --repo "${TAP_REPO}" \
+                --comment "Superseded by newer sync."
+              echo "  ✓ Closed: ${pr_url}"
+            done
+          fi
+
+      # ── 11. Create pull request (only if changes) ──────────────────────────
+      - name: Create pull request
+        id: create-pr
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          cd /tmp/tap-repo
+
+          BRANCH="${{ steps.create-branch.outputs.branch-name }}"
+
+          # Build a summary of changed files
+          SUMMARY=$(git diff --name-status main..."${BRANCH}" 2>/dev/null || echo "Unknown changes")
+
+          PR_URL=$(gh pr create \
+            --repo "${TAP_REPO}" \
+            --title "Sync Homebrew Tap — $(date +%Y-%m-%d)" \
+            --body "## What
+
+          Syncs \`homebrew-tap/\` from \`divisionseven/pkg-defender\` to this tap repository.
+
+          ## Changes
+
+          \`\`\`
+          ${SUMMARY}
+          \`\`\`
+
+          ## Note
+
+          - \`version\`, \`url\`, and \`sha256\` in \`Formula/pkg-defender.rb\` are **preserved** from the current tap state.
+          - All other structural changes (desc, caveats, test block, etc.) are synced from the source.
+
+          Auto-generated by the [sync-homebrew-tap](https://github.com/${{ github.repository }}/actions/workflows/sync-homebrew-tap.yml) workflow." \
+            --head "${BRANCH}" \
+            --base "main")
+
+          PR_NUMBER="${PR_URL##*/}"
+          echo "pull-request-number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "✓ Created PR: ${PR_URL}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Cross-repo sync workflows: Two new GitHub Actions workflows and a Python merge script that automatically sync the `homebrew-tap/` and `github-action/` source-of-truth directories to their respective subsidiary repos (`divisionseven/homebrew-pkg-defender` and `divisionseven/pkg-defender-action`) whenever files in those directories change on `main`.
+  - `.github/workflows/sync-homebrew-tap.yml` — Syncs `homebrew-tap/` → `homebrew-pkg-defender` via PR. Uses a smart-merge script to preserve `version`/`url`/`sha256` from the target formula (set by the release pipeline) while applying all other structural changes (desc, caveats, test block, etc.) from source.
+  - `.github/workflows/sync-github-action.yml` — Syncs `github-action/` → `pkg-defender-action` via full directory rsync, excluding `node_modules/`, `plans/`, and `internal_documentation/`.
+  - `.github/scripts/sync-brew-formula.py` — Standalone Python script for section-aware Homebrew formula merging, preserving only version/URL/SHA256 from the target.
+
 ## [1.0.5] - 2026-07-07
 
 ### Added
@@ -24,9 +31,9 @@ and this project adheres to
 
 ### Fixed
 
-- **`PRAGMA quick_check` on every connection open (root cause of timeout bugs):** `get_connection()` executed `PRAGMA quick_check` on every call, running 5–7 times per `pip install` check against the 668 MB database — cumulative overhead of 30–84 s, exhausting the command timeout budget. Fixed by caching the quick_check result per database path within a process.
-- **Dead, never-used connection in cache-write path:** `dispatcher.py` opened a second connection in `write_threat` that was never actually used. Removed the unused connection.
-- **Cache-write `busy_timeout` now 1 s (was 30 s):** Cache-write connections are documented as best-effort; a 30-second busy wait was inconsistent with that contract. Shortened to 1 s to match the best-effort semantics.
+- `PRAGMA quick_check` on every connection open (root cause of timeout bugs): `get_connection()` executed `PRAGMA quick_check` on every call, running 5–7 times per `pip install` check against the 668 MB database — cumulative overhead of 30–84 s, exhausting the command timeout budget. Fixed by caching the quick_check result per database path within a process.
+- Dead, never-used connection in cache-write path: `dispatcher.py` opened a second connection in `write_threat` that was never actually used. Removed the unused connection.
+- Cache-write `busy_timeout` now 1 s (was 30 s): Cache-write connections are documented as best-effort; a 30-second busy wait was inconsistent with that contract. Shortened to 1 s to match the best-effort semantics.
 
 - Snapshot retrieval system used stale release tag URL construction from previous system design: `fetch_latest_release()` queried `/releases/latest` instead of `/releases/tags/snapshot-latest` via a fragile `git remote` subprocess — `--latest` displayed `N/A` and `0` for real metadata. Fixed by replacing the subprocess approach with hardcoded repo constants and querying the correct tag endpoint.
 - Feed sync progress callback emitted a misleading "completed" message (`(feed_name, 0)`) on error paths — changed to emit `-1` as a sentinel; `handle_feed_complete` now checks for `-1` and reports the failure without claiming zero threats found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to
 
 ### Added
 
+  - Trigger improvements: Both sync workflows now support `workflow_dispatch` (manual trigger from GitHub UI) and a weekly `schedule` (Monday 6am UTC) as safety nets, in addition to the push-based path trigger. This ensures changes are synced even when the push path filter misses them (e.g., when changes span multiple commits and only the HEAD commit matches the path filter, or diff timeouts/limits are hit).
+- Explicit content-based sync detection: Both sync workflows now use `diff -q` / `diff -rq` for file comparison instead of `git status --porcelain`. This provides:
+  - Clear per-file match/mismatch logging in workflow output
+  - True content comparison (not timestamp-based) with no reliance on git commit history
+  - Two-phase detection-then-apply: files are compared before any are copied
+  - A safety-net verification step after apply to catch any discrepancies
+- `sync-brew-formula.py` now supports `--output` flag for two-phase formula detection, enabling the merge result to be inspected before overwriting the target.
 - Cross-repo sync workflows: Two new GitHub Actions workflows and a Python merge script that automatically sync the `homebrew-tap/` and `github-action/` source-of-truth directories to their respective subsidiary repos (`divisionseven/homebrew-pkg-defender` and `divisionseven/pkg-defender-action`) whenever files in those directories change on `main`.
   - `.github/workflows/sync-homebrew-tap.yml` — Syncs `homebrew-tap/` → `homebrew-pkg-defender` via PR. Uses a smart-merge script to preserve `version`/`url`/`sha256` from the target formula (set by the release pipeline) while applying all other structural changes (desc, caveats, test block, etc.) from source.
   - `.github/workflows/sync-github-action.yml` — Syncs `github-action/` → `pkg-defender-action` via full directory rsync, excluding `node_modules/`, `plans/`, and `internal_documentation/`.

--- a/github-action/.github/workflows/ci.yml
+++ b/github-action/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"

--- a/github-action/.github/workflows/release.yml
+++ b/github-action/.github/workflows/release.yml
@@ -32,7 +32,7 @@ concurrency:
 env:
   PROJECT_NAME: "PKG-Defender Action"
   REPO: "${{ github.repository }}"
-  LOGO_LIGHT: "https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_fill.svg"
+  LOGO_LIGHT: "https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_light_mode.svg"
   LOGO_DARK: "https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_transparent.svg"
   LOGO_WIDTH: "300"
 
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0 # full history for git log in release notes
 
@@ -88,7 +88,7 @@ jobs:
 
       # ── Check (b): changelog entry exists ──────────────────────────────────
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
@@ -104,7 +104,7 @@ jobs:
           echo "──────────────────────────────────────────────────────────────"
 
       - name: Upload changelog notes
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: changelog-notes
           path: /tmp/changelog-notes.md
@@ -119,10 +119,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"
@@ -148,10 +148,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "20"
           cache: "npm"
@@ -171,7 +171,7 @@ jobs:
           wc -c dist/index.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: build-artifact
           path: dist/
@@ -187,23 +187,23 @@ jobs:
 
     steps:
       - name: Checkout (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
 
       - name: Download changelog notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: changelog-notes
           path: /tmp/release-assets/
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: build-artifact
           path: /tmp/release-assets/dist/
@@ -241,7 +241,7 @@ jobs:
 
       # ── Create and publish the GitHub Release ─────────────────────────────
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: ${{ needs.validate.outputs.tag }}
           name: "${{ env.PROJECT_NAME }} ${{ needs.validate.outputs.tag }}"
@@ -264,7 +264,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 

--- a/github-action/README.md
+++ b/github-action/README.md
@@ -1,34 +1,34 @@
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_transparent.svg">
-    <img src="https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_fill.svg" alt="pkg-defender" width="500">
+    <img src="https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_light_mode.svg" alt="PKG-Defender Logo" width="500">
   </picture>
 
 # PKG-Defender (PKGD) — Github Action
 
 ### Stop supply chain attacks *before* they reach your machine or CI pipeline
 
+[![Release][github-binary-releases-badge]][github-binary-releases-link]
+[![Snapshot][github-snapshot-releases-badge]][github-snapshot-releases-link]
 [![License][license-badge-icon]][license-badge-link]
 [![Python][python-badge-icon]][pypi-badge-link]
-[![Binary][github-binary-releases-badge]][github-binary-releases-link]
-[![Snapshot][github-snapshot-releases-badge]][github-snapshot-releases-link]
+[![Downloads][pypi-downloads-badge-icon]][pypi-badge-link]
 [![Codecov][codecov-badge-icon]][codecov-badge-link]
 [![Build][ci-badge-icon]][ci-badge-link]
 
-[![Ecosystems][ecosystems-badge-icon]][ecosystems-badge-link]
-[![Systems][systems-badge-icon]][ecosystems-badge-link]
-[![Platforms][platforms-badge-icon]][platforms-badge-link]
+[![Languages][language-pkgs-badge-icon]][ecosystems-badge-link]
+[![Systems][system-pkgs-badge-icon]][ecosystems-badge-link]
+[![Platforms][platforms-badge-icon]][github-binary-releases-link]
 
 </div>
 
-## PKGD Highlights
+## Highlights
 
-> **The supply chain attack defense CLI — Cooldown gates, multi-source threat
+> ***The supply chain attack defense CLI — Cooldown gates, multi-source threat
 > intelligence, command wrappers, CI/CD interception, and lock file dependency
-> auditing for all major package managers.**
+> auditing for all major package managers.***
 
-- **Unified Command Wrapper**:
-  `pkgd [OPTIONS] MANAGER SUBCOMMAND [PACKAGE...] [MANAGER_OPTIONS...]`
+- **Unified Command Wrapper**: `pkgd [OPTIONS] MANAGER SUBCOMMAND [PACKAGE...] [MANAGER_OPTIONS...]`
   - Wrap any [supported][supported-commands] *"dangerous"* package manager
     command (`pkgd pip install requests`, `pkgd npm install express`,
     `pkgd brew upgrade tree`, etc.)
@@ -44,7 +44,8 @@
 - **Alternative PM Coverage**: `python -m pip`, `pipx`, `yarn`, `pnpm` and other
   alt manager calls all [supported][supported-commands]
 - **Cooldown Gates**: configurable time-since-release hold window with
-  per-package, tracked and auditable overrides (ships with a default of 7 days)
+  per-package, tracked and auditable overrides (ships with a default of 7
+  days)
 - **Multi-source Threat Intelligence**: OSV.dev, GHSA, Socket.dev, npm
   advisories, and more all synced and stored locally (with automatic staleness
   detection)
@@ -58,9 +59,9 @@
 - **CI/CD Integration**: `--fail-on-threat` exits on CRITICAL/HIGH for secure
   pipeline gating
 
-[Full Documentation Index &rarr;][docs-index]
+[See Full Documentation Index &rarr;][docs-index]
 
-## Usage
+## PKG-Defender Github Action
 
 ### Basic Usage
 
@@ -361,7 +362,7 @@ The CI/CD integration has three layers:
 ### Contributing
 
 This action repository contains only the GitHub action source for
-`pkg-defender`. For feature requests, bug reports, or contributions to the tool
+PKG-Defender. For feature requests, bug reports, or contributions to the tool
 itself, please visit the
 [main project repository](https://github.com/divisionseven/pkg-defender) and
 review its
@@ -370,7 +371,7 @@ review its
 ### License
 
 This action is licensed under the Apache License, Version 2.0. See
-[LICENSE][license] for the full license text. The main `pkg-defender` tool
+[LICENSE][license] for the full license text. The main `pkg-defender` repository
 is also Apache-2.0 licensed, [see license here][pkgd-repo-license].
 
 ---
@@ -379,8 +380,8 @@ is also Apache-2.0 licensed, [see license here][pkgd-repo-license].
 
 <strong>Last Updated: 2026-07-06</strong></br>
 
-<em>Thank you for supporting PKG-Defender!</em></br>
-<em>— Division 7</em>
+<em><small>Thank you for supporting PKG-Defender!</small></em></br>
+<em><small>— Division 7</small></em>
 
 </div>
 
@@ -390,24 +391,24 @@ is also Apache-2.0 licensed, [see license here][pkgd-repo-license].
 
 [license-badge-icon]: https://img.shields.io/badge/license-Apache_2.0-blue?style=plastic&logo=apache&color=black&logoColor=white&label=License
 [python-badge-icon]: https://img.shields.io/pypi/pyversions/pkg-defender?style=plastic&logo=python&color=black&logoColor=white&label=Python
-[codecov-badge-icon]: https://img.shields.io/codecov/c/github/divisionseven/pkg-defender?logo=codecov&style=plastic&color=black&logoColor=white&label=Codecov
+[pypi-downloads-badge-icon]: https://img.shields.io/pepy/dt/pkg-defender?style=plastic&logo=pypi&color=black&logoColor=white&label=Downloads
 [github-binary-releases-badge]: https://img.shields.io/github/v/release/divisionseven/pkg-defender?filter=v*&style=plastic&color=black&logo=git&logoColor=white&label=Release
-[github-snapshot-releases-badge]: https://img.shields.io/github/v/tag/divisionseven/pkg-defender?filter=snapshot-latest&style=plastic&logo=sqlite&logoColor=white&color=black&label=Snapshot
+[github-snapshot-releases-badge]: https://img.shields.io/github/v/tag/divisionseven/pkg-defender?filter=snapshot-latest&style=plastic&logo=sqlite&logoColor=white&color=black&label=Threat%20DB
+[codecov-badge-icon]: https://img.shields.io/codecov/c/github/divisionseven/pkg-defender?logo=codecov&style=plastic&color=black&logoColor=white&label=Codecov
 [ci-badge-icon]: https://img.shields.io/github/actions/workflow/status/divisionseven/pkg-defender/ci.yml?branch=main&logo=github&style=plastic&color=black&logoColor=white&label=Build
-[ecosystems-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?style=plastic
-[systems-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?style=plastic
+[language-pkgs-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?style=plastic
+[system-pkgs-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?style=plastic
 [platforms-badge-icon]: https://img.shields.io/badge/Platforms-macOS%20%7C%20Linux%20%7C%20Windows-black?style=plastic
 
 <!-- Header Badge Links -->
 
 [license-badge-link]: https://opensource.org/licenses/Apache-2.0
 [pypi-badge-link]: https://pypi.org/project/pkg-defender/
-[codecov-badge-link]: https://app.codecov.io/gh/divisionseven/pkg-defender
 [github-binary-releases-link]: https://github.com/divisionseven/pkg-defender/releases
 [github-snapshot-releases-link]: https://github.com/divisionseven/pkg-defender/releases/tag/snapshot-latest
+[codecov-badge-link]: https://app.codecov.io/gh/divisionseven/pkg-defender
 [ci-badge-link]: https://github.com/divisionseven/pkg-defender/actions/workflows/ci.yml
-[platforms-badge-link]: https://github.com/divisionseven/pkg-defender
-[ecosystems-badge-link]: docs/reference/package-managers.md
+[ecosystems-badge-link]: https://github.com/divisionseven/pkg-defender/blob/main/docs/reference/package-managers.md
 
 <!-- Body Badge Icons -->
 

--- a/homebrew-tap/.github/workflows/tests.yml
+++ b/homebrew-tap/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
       # Cache Bundler RubyGems between runs for faster setup
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/homebrew-tap/Formula/pkg-defender.rb
+++ b/homebrew-tap/Formula/pkg-defender.rb
@@ -16,7 +16,7 @@
 class PkgDefender < Formula
   desc "Stop supply chain attacks before they reach your machine or CI pipeline"
   homepage "https://github.com/divisionseven/pkg-defender"
-  version "1.0.3"
+  version "1.0.5"
   license "Apache-2.0"
 
   livecheck do
@@ -26,8 +26,8 @@ class PkgDefender < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/divisionseven/pkg-defender/releases/download/v1.0.3/pkgd-darwin-arm64"
-      sha256 "080b26cff27e5cb3bfd677503b9d04d5070ddf0434db27c8929fb25dab34832c"
+      url "https://github.com/divisionseven/pkg-defender/releases/download/v1.0.5/pkgd-darwin-arm64"
+      sha256 "3210e98e2928c246eae7a206d83b3119dce90bf38777216306cc3d56a071d091"
 
       define_method(:install) do
         bin.install "pkgd-darwin-arm64" => "pkgd"
@@ -35,8 +35,8 @@ class PkgDefender < Formula
     end
 
     on_intel do
-      url "https://github.com/divisionseven/pkg-defender/releases/download/v1.0.3/pkgd-darwin-amd64"
-      sha256 "8cbe6f63a409c8bb614480ffe7070342bde35471237fa070bfaff69205ced1e7"
+      url "https://github.com/divisionseven/pkg-defender/releases/download/v1.0.5/pkgd-darwin-amd64"
+      sha256 "76636f5f2b4a4ec61d085a41a94f7d0e68f76ec66a3d9f26bf2604f4f9eadc40"
 
       define_method(:install) do
         bin.install "pkgd-darwin-amd64" => "pkgd"
@@ -46,8 +46,8 @@ class PkgDefender < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/divisionseven/pkg-defender/releases/download/v1.0.3/pkgd-linux-amd64"
-      sha256 "706315fbb183d4f41ecc431c82c5918cb976f781314391d32201ddacc45b1669"
+      url "https://github.com/divisionseven/pkg-defender/releases/download/v1.0.5/pkgd-linux-amd64"
+      sha256 "549bf452c9bed558856d5d32be6a66e42804672056b99e53221e89d5deafa541"
 
       define_method(:install) do
         bin.install "pkgd-linux-amd64" => "pkgd"

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -1,33 +1,35 @@
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_transparent.svg">
-    <img src="https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_fill.svg" alt="pkg-defender" width="500">
+    <img src="https://raw.githubusercontent.com/divisionseven/pkg-defender/main/docs/assets/brand/logo/pkgd_logo_light_mode.svg" alt="PKG-Defender Logo" width="500">
   </picture>
 
 # PKG-Defender (PKGD) — Homebrew Tap
 
 ### Stop supply chain attacks *before* they reach your machine or CI pipeline
 
+[![Release][github-binary-releases-badge]][github-binary-releases-link]
+[![Snapshot][github-snapshot-releases-badge]][github-snapshot-releases-link]
 [![License][license-badge-icon]][license-badge-link]
 [![Python][python-badge-icon]][pypi-badge-link]
-[![Binary][github-binary-releases-badge]][github-binary-releases-link]
-[![Snapshot][github-snapshot-releases-badge]][github-snapshot-releases-link]
+[![Downloads][pypi-downloads-badge-icon]][pypi-badge-link]
 [![Codecov][codecov-badge-icon]][codecov-badge-link]
 [![Build][ci-badge-icon]][ci-badge-link]
 
-[![Ecosystems][ecosystems-badge-icon]][ecosystems-badge-link]
-[![Systems][systems-badge-icon]][ecosystems-badge-link]
-[![Platforms][platforms-badge-icon]][platforms-badge-link]
+[![Languages][language-pkgs-badge-icon]][ecosystems-badge-link]
+[![Systems][system-pkgs-badge-icon]][ecosystems-badge-link]
+[![Platforms][platforms-badge-icon]][github-binary-releases-link]
 
 </div>
 
-## PKGD Highlights
+## Highlights
 
-> **The supply chain attack defense CLI — Cooldown gates, multi-source threat
+> ***The supply chain attack defense CLI — Cooldown gates, multi-source threat
 > intelligence, command wrappers, CI/CD interception, and lock file dependency
-> auditing for all major package managers.**
+> auditing for all major package managers.***
 
-- **Unified Command Wrapper**: `pkgd [OPTIONS] MANAGER SUBCOMMAND [PACKAGE...] [MANAGER_OPTIONS...]`
+- **Unified Command Wrapper**:
+  `pkgd [OPTIONS] MANAGER SUBCOMMAND [PACKAGE...] [MANAGER_OPTIONS...]`
   - Wrap any [supported][supported-commands] *"dangerous"* package manager
     command (`pkgd pip install requests`, `pkgd npm install express`,
     `pkgd brew upgrade tree`, etc.)
@@ -43,8 +45,7 @@
 - **Alternative PM Coverage**: `python -m pip`, `pipx`, `yarn`, `pnpm` and other
   alt manager calls all [supported][supported-commands]
 - **Cooldown Gates**: configurable time-since-release hold window with
-  per-package, tracked and auditable overrides (ships with a default of 7
-  days)
+  per-package, tracked and auditable overrides (ships with a default of 7 days)
 - **Multi-source Threat Intelligence**: OSV.dev, GHSA, Socket.dev, npm
   advisories, and more all synced and stored locally (with automatic staleness
   detection)
@@ -58,20 +59,30 @@
 - **CI/CD Integration**: `--fail-on-threat` exits on CRITICAL/HIGH for secure
   pipeline gating
 
-[Full Documentation Index &rarr;][docs-index]
+[See Full Documentation Index &rarr;][docs-index]
 
 ## PKG-Defender Homebrew Tap
 
-Homebrew tap for [PKG-Defender (PKGD)](https://github.com/divisionseven/pkg-defender) — the supply chain attack defense CLI that stops malicious packages before they reach your machine or CI pipeline.
+Homebrew tap for
+[PKG-Defender (PKGD)](https://github.com/divisionseven/pkg-defender) — the
+supply chain attack defense CLI that stops malicious packages before they reach
+your machine or CI pipeline.
 
-### Installation
+### Installation From Homebrew (macOS/Linux)
 
-```sh
+```bash
 brew tap divisionseven/pkg-defender
 brew install pkg-defender
 ```
 
-> **Note for Homebrew 6.0+:** You may be prompted to run `brew trust divisionseven/pkg-defender` if Homebrew's automatic trust evaluation requires confirmation.
+**Tap Trust (Homebrew 6.0.0+)**
+
+As of Homebrew 6.0.0, brew's automatic trust evaluation requires explicit trust
+confirmation for taps. If needed, users may be prompted to run:
+
+```bash
+brew trust divisionseven/pkg-defender
+```
 
 ### Verification
 
@@ -98,15 +109,29 @@ brew untap divisionseven/pkg-defender
 
 ### Contributing
 
-This tap repository contains only the Homebrew formula for distributing `pkg-defender`. For feature requests, bug reports, or contributions to the tool itself, please visit the [main project repository](https://github.com/divisionseven/pkg-defender) and review its [contributing guide](https://github.com/divisionseven/pkg-defender/blob/main/CONTRIBUTING.md).
+This tap repository contains only the Homebrew formula for distributing
+PKG-Defender. For feature requests, bug reports, or contributions to the tool
+itself, please visit the
+[main project repository](https://github.com/divisionseven/pkg-defender) and
+review its
+[contributing guide](https://github.com/divisionseven/pkg-defender/blob/main/CONTRIBUTING.md).
 
 ### License
 
-This tap is licensed under the Apache License, Version 2.0. See [LICENSE][license] for the full license text. The packaged `pkg-defender` tool is also Apache-2.0 licensed, [see license here][pkgd-repo-license].
+This tap is licensed under the Apache License, Version 2.0. See
+[LICENSE][license] for the full license text. The packaged `pkg-defender` tool
+is also Apache-2.0 licensed, [see main license here][pkgd-repo-license].
 
 ---
 
-**Last updated:** 2026-07-02
+<div align="center">
+
+<strong>Last Updated: 2026-07-11</strong></br>
+
+<em><small>Thank you for supporting PKG-Defender!</small></em></br> <em><small>—
+Division 7</small></em>
+
+</div>
 
 ---
 
@@ -114,24 +139,24 @@ This tap is licensed under the Apache License, Version 2.0. See [LICENSE][licens
 
 [license-badge-icon]: https://img.shields.io/badge/license-Apache_2.0-blue?style=plastic&logo=apache&color=black&logoColor=white&label=License
 [python-badge-icon]: https://img.shields.io/pypi/pyversions/pkg-defender?style=plastic&logo=python&color=black&logoColor=white&label=Python
-[codecov-badge-icon]: https://img.shields.io/codecov/c/github/divisionseven/pkg-defender?logo=codecov&style=plastic&color=black&logoColor=white&label=Codecov
+[pypi-downloads-badge-icon]: https://img.shields.io/pepy/dt/pkg-defender?style=plastic&logo=pypi&color=black&logoColor=white&label=Downloads
 [github-binary-releases-badge]: https://img.shields.io/github/v/release/divisionseven/pkg-defender?filter=v*&style=plastic&color=black&logo=git&logoColor=white&label=Release
-[github-snapshot-releases-badge]: https://img.shields.io/github/v/tag/divisionseven/pkg-defender?filter=snapshot-latest&style=plastic&logo=sqlite&logoColor=white&color=black&label=Snapshot
+[github-snapshot-releases-badge]: https://img.shields.io/github/v/tag/divisionseven/pkg-defender?filter=snapshot-latest&style=plastic&logo=sqlite&logoColor=white&color=black&label=Threat%20DB
+[codecov-badge-icon]: https://img.shields.io/codecov/c/github/divisionseven/pkg-defender?logo=codecov&style=plastic&color=black&logoColor=white&label=Codecov
 [ci-badge-icon]: https://img.shields.io/github/actions/workflow/status/divisionseven/pkg-defender/ci.yml?branch=main&logo=github&style=plastic&color=black&logoColor=white&label=Build
-[ecosystems-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?style=plastic
-[systems-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?style=plastic
+[language-pkgs-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?style=plastic
+[system-pkgs-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?style=plastic
 [platforms-badge-icon]: https://img.shields.io/badge/Platforms-macOS%20%7C%20Linux%20%7C%20Windows-black?style=plastic
 
 <!-- Header Badge Links -->
 
 [license-badge-link]: https://opensource.org/licenses/Apache-2.0
 [pypi-badge-link]: https://pypi.org/project/pkg-defender/
-[codecov-badge-link]: https://app.codecov.io/gh/divisionseven/pkg-defender
 [github-binary-releases-link]: https://github.com/divisionseven/pkg-defender/releases
 [github-snapshot-releases-link]: https://github.com/divisionseven/pkg-defender/releases/tag/snapshot-latest
+[codecov-badge-link]: https://app.codecov.io/gh/divisionseven/pkg-defender
 [ci-badge-link]: https://github.com/divisionseven/pkg-defender/actions/workflows/ci.yml
-[platforms-badge-link]: https://github.com/divisionseven/pkg-defender
-[ecosystems-badge-link]: docs/reference/package-managers.md
+[ecosystems-badge-link]: https://github.com/divisionseven/pkg-defender/blob/main/docs/reference/package-managers.md
 
 <!-- Internal Documentation Links -->
 


### PR DESCRIPTION
<!-- PR TITLE: Use Conventional Commits: <type>(<scope>): <description>
     Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
     Example: feat(cli): add --json flag to audit command
     See CONTRIBUTING.md for the full specification. -->

<!-- TARGET BRANCH: Feature, fix, and doc branches → `develop`. Hotfixes → `main`.
     See CONTRIBUTING.md for branching strategy. -->

## Summary

<!-- Provide a concise description of the changes in this PR. What problem does it solve? What does it add or change? -->

Adds automated cross-repo sync workflows that propagate structural changes from the monorepo's `homebrew-tap/` and `github-action/` source-of-truth directories to their respective subsidiary repos (`divisionseven/homebrew-pkg-defender` and `divisionseven/pkg-defender-action`). The sync uses explicit content-based `diff` comparison (not git commit history) to detect changes, and opens a PR on the downstream repos when differences are found.

**Key components:**
- `.github/workflows/sync-homebrew-tap.yml` — syncs 5 managed files to the tap repo, with smart formula merging that preserves `version`/`url`/`sha256` from the target
- `.github/workflows/sync-github-action.yml` — rsyncs the full `github-action/` directory to the action repo
- `.github/scripts/sync-brew-formula.py` — Homebrew formula merge script that only overwrites structural fields; protected fields (version/url/sha256) are preserved from the target

Closes #<!-- N/A — internal tooling improvement, not tied to an issue -->

---

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔒 Security fix
- [ ] ♻️ Refactor (no functional changes)
- [ ] 📖 Documentation update
- [ ] 🧪 Tests only
- [x] 🏗️ Build / CI / dependency update
- [ ] ⚡ Performance improvement
- [ ] 🎨 Style (formatting, no logic change)
- [x] 🧹 Chore (formatting, renaming, cleanup)

<!-- LABELS: After creating your PR, apply the appropriate GitHub labels.
     Type labels: bug, enhancement, documentation, security, performance, chore
     Area labels: area:cli, area:audit, area:cooldown-engine, area:threat-intelligence, etc.
     See .github/labels.yml for the full taxonomy. -->

---

## Motivation and Context

<!-- Why is this change needed? What problem does it solve?
     If it fixes a bug, describe the root cause. If it adds a feature, describe the use case. -->

The main `pkg-defender` repository is the source of truth for two subsidiary repos — the Homebrew tap (`divisionseven/homebrew-pkg-defender`) and the GitHub Action (`divisionseven/pkg-defender-action`). Previously, only the tap repo's formula version/URL/SHA256 values were synced (by the release pipeline). All other structural changes — updates to `desc`, `caveats`, `test do` blocks, the action's `index.js`, `action.yml`, CI workflows, README, LICENSE, etc. — required manual duplication.

This change automates that sync. When files in `homebrew-tap/` or `github-action/` are pushed to `main` or `develop` (or manually triggered, or weekly via schedule), the workflows compare current content against the downstream repos and open a PR with any differences.

---

## Implementation Notes

<!-- Any implementation details, design decisions, or trade-offs worth highlighting for reviewers. -->

**Two-phase detection-then-apply:** All workflows use a two-phase approach — detection (`diff -q` / `diff -rq`) runs first and logs per-file match/mismatch results. Only if content differs are files copied and committed. This ensures zero side effects during the comparison phase.

**Formula protection:** The `sync-brew-formula.py` script uses regex-based line matching to identify `version`, `url`, and `sha256` lines and always emits the target's values for those fields. Everything else (desc, license, caveats, test do, install methods, etc.) comes from the source. A `--output` flag supports inspection-before-apply.

**Trigger reliability:** Three trigger mechanisms guard against GitHub Actions path filter edge cases:
- `push` with path filter (fast feedback when HEAD commit matches)
- `workflow_dispatch` (manual trigger via UI)
- `schedule` weekly cron (safety net — Monday 6am UTC)

**Why `diff` instead of `rsync --dry-run`:** `rsync -a` uses file timestamps for its quick check, causing false positives when comparing files from two separate git checkouts with identical content but different timestamps. `diff -q`/`diff -rq` is truly content-based.

---

## Testing

<!-- Describe how you tested your changes. -->

- [ ] I have added tests that cover the changes in this PR
- [x] All existing tests pass locally (`pytest --cov-fail-under=90`)
- [x] I have run the e2e gate test locally (`pytest tests/integration/test_smoke_e2e.py --tb=short -q`)
- [x] I have tested this manually (describe what you did below)

**Manual testing performed:**
- `sync-brew-formula.py` tested with 7 scenarios (37 assertions): basic merge, multiple protected fields, empty source/target, different counts, no protected fields, missing platform — all pass
- `--output` flag tested: writes to specified path, backward compatible (no `--output` writes to target), detection phase produces correct temp output
- Both workflow YAML files validated with `yaml.safe_load` — structurally valid
- `ruff check` and `mypy --strict` pass on sync-brew-formula.py
- Zero remaining `steps.check-changes` references (all migrated to `steps.compare`)

---

## Checklist

- [x] My code follows the project's style guidelines (passes `ruff check .` and `ruff format --check .`)
- [x] My code passes type checking (`mypy .`)
- [x] My changes maintain or improve code coverage (`pytest --cov-fail-under=90`)
- [x] My CLI changes use the correct exit codes defined in `docs/reference/exit-codes.md`
- [x] I have updated documentation as needed (README, docstrings, CHANGELOG)
- [x] I have updated `CHANGELOG.md` with a brief entry under `[Unreleased]`
- [x] My changes do not introduce new dependencies without discussion
- [x] Any new dependencies are pinned appropriately in `pyproject.toml`
- [x] I am aware that the dependency review workflow (`.github/workflows/dependency-review.yml`) runs automatically on PRs
- [x] I have reviewed my own diff before requesting review

---

## Screenshots / Output

<!-- If this change affects the CLI output, UI, or terminal rendering, please include before/after screenshots or terminal recordings. -->

N/A — GitHub Actions workflow changes, no CLI output affected.

---

## Breaking Changes

<!-- If this is a breaking change, describe exactly what breaks and what users need to do to migrate.
     Leave this section blank if not applicable. -->

None. All files are additive (new workflows, new script). No existing interfaces, APIs, or CLI commands are modified.

---

## Related Issues / PRs

<!-- Link any related issues, PRs, or external references. -->

- Subsidiary repos: `divisionseven/pkg-defender-action`, `divisionseven/homebrew-pkg-defender`