### PR TITLE
feat(security): prepare for OpenSSF Best Practices Badge certification

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# .github/workflows/codeql.yml
+#
+# CodeQL SAST Scanning
+# ──────────────────────────────────────────────────────────────────────────────
+# Triggers:
+#   • Push to main / develop
+#   • Pull requests targeting main / develop
+#   • Weekly schedule: Monday 06:00 UTC
+#   • workflow_dispatch — manual trigger
+#
+# Jobs:
+#   analyze → CodeQL analysis (ubuntu-latest, python)
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: 🔎 CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# ──────────────────────────────────────────────────────────────────────────────
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-*"   # pre-release: v1.2.3-beta.1
 
 permissions:
-  contents: write # required to create GitHub Releases
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -131,6 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, ci]
 
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -197,6 +200,23 @@ jobs:
           path: dist/
           retention-days: 1
 
+      - name: Generate hashes for provenance
+        id: hash
+        run: |
+          cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    name: Generate SLSA provenance
+    runs-on: ubuntu-latest
+    needs: [validate, ci, build]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563  # v2.0.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.hashes }}
+
   # ── Job 4: Build Docker Images ──────────────────────────────────────────────
   # Builds multi-arch Docker images (linux/amd64, linux/arm64) and pushes
   # to GitHub Container Registry (GHCR). Runs concurrently with build and
@@ -238,6 +258,7 @@ jobs:
             type=raw,value=latest,enable=${{ !needs.validate.outputs.prerelease }}
 
       - name: Build and push multi-arch image
+        id: build-image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
@@ -257,6 +278,13 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
+      - name: Attest Docker image provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-image.outputs.digest }}
+          push-to-registry: true
+
   # ── Job 5: Build Binaries ───────────────────────────────────────────────────
   # Builds standalone PyInstaller binaries for all target platforms.
   # Outputs: pkgd-linux-amd64, pkgd-darwin-amd64, pkgd-darwin-arm64, pkgd-windows-amd64.exe
@@ -264,6 +292,11 @@ jobs:
     name: Build Binary (${{ matrix.binary_name }})
     runs-on: ${{ matrix.os }}
     needs: [validate, ci]
+
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
 
     strategy:
       fail-fast: false # complete all builds even if one fails
@@ -321,6 +354,11 @@ jobs:
           print(f"SHA256({binary_name}) = {h}")
           PYEOF
 
+      - name: Attest binary provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v2.4.0
+        with:
+          subject-path: 'dist/${{ matrix.binary_name }}'
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: binary-artifacts-${{ matrix.binary_name }}
@@ -334,7 +372,10 @@ jobs:
   github-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate, build, build-binaries, build-docker]
+    needs: [validate, build, build-binaries, build-docker, provenance]
+
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout (full history for git log)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,6 @@ jobs:
 
   provenance:
     name: Generate SLSA provenance
-    runs-on: ubuntu-latest
     needs: [validate, ci, build]
     permissions:
       actions: read
@@ -229,6 +228,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# .github/workflows/scorecard.yml
+#
+# OpenSSF Scorecard Analysis
+# ──────────────────────────────────────────────────────────────────────────────
+# Triggers:
+#   • Push to main
+#   • Weekly schedule (Monday 06:00 UTC)
+#   • workflow_dispatch
+#
+# Jobs:
+#   analysis → run OpenSSF Scorecard analysis and upload results to Code Scanning
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: 📊 OSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# Declare default permissions as read-only
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+  - Property-based fuzzing tests using hypothesis — 6 invariants verified
+    for threat scoring logic (`tests/unit/core/test_scoring_properties.py`)
+  - hypothesis>=6.0 dependency added to test profile
   - Trigger improvements: Both sync workflows now support `workflow_dispatch` (manual trigger from GitHub UI) and a weekly `schedule` (Monday 6am UTC) as safety nets, in addition to the push-based path trigger. This ensures changes are synced even when the push path filter misses them (e.g., when changes span multiple commits and only the HEAD commit matches the path filter, or diff timeouts/limits are hit).
 - Explicit content-based sync detection: Both sync workflows now use `diff -q` / `diff -rq` for file comparison instead of `git status --porcelain`. This provides:
   - Clear per-file match/mismatch logging in workflow output
@@ -40,6 +43,7 @@ and this project adheres to
 
 ### Security
 
+  - Hypothesis property-based fuzzing tests added for threat scoring invariants
   - CodeQL SAST scanning workflow (`.github/workflows/codeql.yml`) — runs on push/PR to main/develop and weekly schedule for Python code analysis
   - OpenSSF Scorecard analysis workflow (`.github/workflows/scorecard.yml`) — evaluates repository security posture, pushes results to Scorecard API and uploads SARIF to code scanning
   - SLSA Build Level 3 provenance generation in release pipeline via `slsa-github-generator` — provides verifiable build integrity attestations for all release artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+  - `GOVERNANCE.md` — project governance document defining roles, decision-making, and conflict resolution processes
+  - Secure design principles statement in `docs/explanation/security-model.md`
   - Property-based fuzzing tests using hypothesis — 6 invariants verified
     for threat scoring logic (`tests/unit/core/test_scoring_properties.py`)
   - hypothesis>=6.0 dependency added to test profile
@@ -33,6 +35,10 @@ and this project adheres to
   - `scripts/add_spdx_headers.py` — automated script for managing SPDX and copyright headers across the codebase
 
 ### Changed
+
+  - `CONTRIBUTING.md` — added Developer Certificate of Origin (DCO) requirement with sign-off instructions
+  - `docs/explanation/security-model.md` — added Secure Design Principles section covering fail-closed, least privilege, defense in depth, secure defaults, and input validation
+  - `README.md` — added OpenSSF Scorecard and OpenSSF Best Practices (placeholder) badges to header
 
   - Downstream workflow commits (`release.yml`, `sync-homebrew-tap.yml`, `sync-github-action.yml`) now authored as `Division 7` with `Co-authored-by: github-actions[bot]` instead of pure bot authorship for traceability
   - `.github/workflows/release.yml` token permissions scoped from `contents: write` to `contents: read` with per-job overrides, following the least-privilege principle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,32 @@ and this project adheres to
   - `.github/workflows/sync-homebrew-tap.yml` — Syncs `homebrew-tap/` → `homebrew-pkg-defender` via PR. Uses a smart-merge script to preserve `version`/`url`/`sha256` from the target formula (set by the release pipeline) while applying all other structural changes (desc, caveats, test block, etc.) from source.
   - `.github/workflows/sync-github-action.yml` — Syncs `github-action/` → `pkg-defender-action` via full directory rsync, excluding `node_modules/`, `plans/`, and `internal_documentation/`.
   - `.github/scripts/sync-brew-formula.py` — Standalone Python script for section-aware Homebrew formula merging, preserving only version/URL/SHA256 from the target.
+  - CodeQL SAST scanning workflow (`.github/workflows/codeql.yml`) — runs on push/PR to main/develop and weekly schedule for Python code analysis
+  - OpenSSF Scorecard analysis workflow (`.github/workflows/scorecard.yml`) — evaluates repository security posture, pushes results to Scorecard API and uploads SARIF to code scanning
+  - SLSA Build Level 3 provenance generation in release pipeline via `slsa-github-generator` — provides verifiable build integrity attestations for all release artifacts
+  - Binary artifact attestations via `actions/attest-build-provenance` — cryptographically links release binaries to their build workflow
+  - Docker image provenance attestation with push-to-registry in release pipeline
+  - SPDX license and copyright headers (`# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)` and `# SPDX-License-Identifier: Apache-2.0`) added to all 113 source files under `src/pkg_defender/`
+  - `scripts/add_spdx_headers.py` — automated script for managing SPDX and copyright headers across the codebase
 
 ### Changed
 
-- Downstream workflow commits (`release.yml`, `sync-homebrew-tap.yml`, `sync-github-action.yml`) now authored as `Division 7` with `Co-authored-by: github-actions[bot]` instead of pure bot authorship for traceability
+  - Downstream workflow commits (`release.yml`, `sync-homebrew-tap.yml`, `sync-github-action.yml`) now authored as `Division 7` with `Co-authored-by: github-actions[bot]` instead of pure bot authorship for traceability
+  - `.github/workflows/release.yml` token permissions scoped from `contents: write` to `contents: read` with per-job overrides, following the least-privilege principle
 
 ### Fixed
 
-- `sync-github-action` workflow no longer destroys the target downstream repo's `.git/` directory during rsync sync
+  - `sync-github-action` workflow no longer destroys the target downstream repo's `.git/` directory during rsync sync
+
+### Security
+
+  - CodeQL SAST scanning workflow (`.github/workflows/codeql.yml`) — runs on push/PR to main/develop and weekly schedule for Python code analysis
+  - OpenSSF Scorecard analysis workflow (`.github/workflows/scorecard.yml`) — evaluates repository security posture, pushes results to Scorecard API and uploads SARIF to code scanning
+  - SLSA Build Level 3 provenance generation in release pipeline via `slsa-github-generator` — provides verifiable build integrity attestations for all release artifacts
+  - Binary artifact attestations via `actions/attest-build-provenance` — cryptographically links release binaries to their build workflow
+  - Docker image provenance attestation with push-to-registry in release pipeline
+  - SPDX license and copyright headers (`# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)` and `# SPDX-License-Identifier: Apache-2.0`) added to all 113 source files under `src/pkg_defender/`
+  - `scripts/add_spdx_headers.py` — automated script for managing SPDX and copyright headers across the codebase
 
 ## [1.0.5] - 2026-07-07
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -534,6 +534,32 @@ PKG-Defender follows the [Conventional Commits](https://www.conventionalcommits.
 | `chore`    | Maintenance, tooling, minor tasks          |
 | `revert`   | Reverting a previous change                |
 
+### Developer Certificate of Origin (DCO)
+
+This project requires all contributors to certify that their contributions
+comply with the [Developer Certificate of Origin (DCO) v1.1](https://developercertificate.org/).
+
+By signing off your commits, you certify that you have the right to submit
+the code under the project's license and that you understand the contribution
+is made under the terms of the [Apache 2.0 License](./LICENSE).
+
+**How to sign off:** Use `git commit -s` to automatically add a
+`Signed-off-by` trailer to your commit message. The trailer should look like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+If you forget to sign off on a commit, you can amend it:
+
+```bash
+git commit --amend -s
+```
+
+The DCO check must pass for all commits in a pull request before it can be
+merged. You can install the [DCO GitHub App](https://github.com/apps/dco)
+on your repository to automate this check.
+
 ---
 
 ## Pull Request Process

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,60 @@
+# Project Governance
+
+## Project Governance
+
+This project is maintained by [DIVISION 7](https://github.com/divisionseven), the sole maintainer of PKG-Defender. The maintainer has final authority on all project decisions, including but not limited to feature acceptance, release scheduling, and strategic direction.
+
+## Decision-Making Process
+
+- The maintainer has final authority over all decisions related to the project.
+- Design discussions and substantial feature proposals take place in [GitHub Issues](https://github.com/divisionseven/pkg-defender/issues) and [GitHub Discussions](https://github.com/divisionseven/pkg-defender/discussions).
+- Significant changes — including new features, API modifications, or behavioral changes — follow the review process described in [CONTRIBUTING.md](./CONTRIBUTING.md).
+- Small changes and bug fixes can be submitted directly as pull requests. The maintainer will review and merge them in a timely manner.
+
+## Roles
+
+### Maintainer
+
+The maintainer is responsible for:
+
+- Setting the project's technical direction and roadmap
+- Reviewing and merging contributions
+- Managing releases and versioning
+- Enforcing project standards and community guidelines
+- Making final decisions on any project matter
+
+### Contributor
+
+A contributor is anyone who participates in the project by:
+
+- Submitting pull requests with bug fixes, features, or improvements
+- Reporting bugs through GitHub Issues
+- Suggesting features or enhancements
+- Participating in discussions and providing feedback
+- Improving documentation or tests
+
+All contributors are expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Becoming a Maintainer
+
+The project is currently not accepting new maintainers — it is an org-owned project managed by DIVISION 7. This may be revisited in the future.
+
+When the position is open, candidates for maintainer would be evaluated against the following criteria:
+
+- A sustained record of high-quality contributions to the project
+- Demonstrated understanding of the codebase, the security threat landscape PKG-Defender addresses, and the project's security model
+- Consistent adherence to project standards, coding conventions, and community norms
+- Approval from the existing maintainer
+
+## Conflict Resolution
+
+- The maintainer's decision on any matter is final.
+- Contributors who disagree with a decision may appeal by providing new information, evidence, or rationale that was not previously considered.
+- The maintainer will re-evaluate the decision within a reasonable timeframe after receiving an appeal.
+
+## Cross-References
+
+- [Contributing Guide](./CONTRIBUTING.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Security Policy](./SECURITY.md)
+- [GitHub Repository](https://github.com/divisionseven/pkg-defender)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2026 DIVISION 7 | MI-7
+   Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
 [![Systems][system-pkgs-badge-icon]][ecosystems-badge-link]
 [![Platforms][platforms-badge-icon]][github-binary-releases-link]
 
+[![OpenSSF Best Practices][ossf-bp-badge-icon]][ossf-bp-badge-link]
+[![OpenSSF Scorecard][scorecard-badge-icon]][scorecard-badge-link]
+
 </div>
 
 ## Highlights
@@ -958,6 +961,8 @@ above with full transparency audit links.
 [language-pkgs-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?style=plastic
 [system-pkgs-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?style=plastic
 [platforms-badge-icon]: https://img.shields.io/badge/Platforms-macOS%20%7C%20Linux%20%7C%20Windows-black?style=plastic
+[ossf-bp-badge-icon]: https://img.shields.io/badge/openssf%20best%20practices-pending-black?style=plastic&color=black&label=OpenSSF%20Best%20Practices
+[scorecard-badge-icon]: https://img.shields.io/ossf-scorecard/github.com/divisionseven/pkg-defender?style=plastic&color=black&logoColor=white&label=OpenSSF%20Scorecard
 
 <!-- Header Badge Links -->
 
@@ -968,6 +973,8 @@ above with full transparency audit links.
 [codecov-badge-link]: https://app.codecov.io/gh/divisionseven/pkg-defender
 [ci-badge-link]: https://github.com/divisionseven/pkg-defender/actions/workflows/ci.yml
 [ecosystems-badge-link]: docs/reference/package-managers.md
+[ossf-bp-badge-link]: https://bestpractices.coreinfrastructure.org/projects/<PROJECT_ID>
+[scorecard-badge-link]: https://securityscorecards.dev/viewer/?uri=github.com/divisionseven/pkg-defender
 
 <!-- Body Badge Icons -->
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
 
 [![Languages][language-pkgs-badge-icon]][ecosystems-badge-link]
 [![Systems][system-pkgs-badge-icon]][ecosystems-badge-link]
-[![Platforms][platforms-badge-icon]][github-binary-releases-link]
-
 [![OpenSSF Best Practices][ossf-bp-badge-icon]][ossf-bp-badge-link]
 [![OpenSSF Scorecard][scorecard-badge-icon]][scorecard-badge-link]
 
@@ -99,6 +97,8 @@ threat intelligence** and **dependency auditing** combined with a configurable
 machine, your dependency tree, or your production pipelines.
 
 ## Installation
+
+[![Platforms][platforms-badge-icon]][github-binary-releases-link]
 
 ### From PyPI
 
@@ -960,7 +960,6 @@ above with full transparency audit links.
 [ci-badge-icon]: https://img.shields.io/github/actions/workflow/status/divisionseven/pkg-defender/ci.yml?branch=main&logo=github&style=plastic&color=black&logoColor=white&label=Build
 [language-pkgs-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?style=plastic
 [system-pkgs-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?style=plastic
-[platforms-badge-icon]: https://img.shields.io/badge/Platforms-macOS%20%7C%20Linux%20%7C%20Windows-black?style=plastic
 [ossf-bp-badge-icon]: https://img.shields.io/badge/openssf%20best%20practices-pending-black?style=plastic&color=black&label=OpenSSF%20Best%20Practices
 [scorecard-badge-icon]: https://img.shields.io/ossf-scorecard/github.com/divisionseven/pkg-defender?style=plastic&color=black&logoColor=white&label=OpenSSF%20Scorecard
 
@@ -978,6 +977,7 @@ above with full transparency audit links.
 
 <!-- Body Badge Icons -->
 
+[platforms-badge-icon]: https://img.shields.io/badge/Compatible_Platforms-macOS%20ARM64%2Fx86__64%20%7C%20Linux%20x86__64%20%7C%20Windows%20x86__64-black?style=plastic
 [pkgd-action-release-badge-icon]: https://img.shields.io/github/v/release/divisionseven/pkg-defender-action?filter=v*&style=plastic&color=black&logo=git&logoColor=white&label=PKGD%20GitHub%20Action%20Release
 [pkgd-action-ci-badge-icon]: https://img.shields.io/github/actions/workflow/status/divisionseven/pkg-defender-action/ci.yml?branch=main&logo=github&style=plastic&color=black&logoColor=white&label=PKGD%20GitHub%20Action%20Build
 [snapshot-action-badge-icon]: https://img.shields.io/github/actions/workflow/status/divisionseven/pkg-defender/snapshot.yml?branch=main&logo=github&style=plastic&color=black&logoColor=white&label=PKGD%20Snapshot%20Build

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -638,7 +638,6 @@ All security features default to the most conservative settings:
 
 Domain allowlists prevent SSRF attacks by restricting outbound connections to known threat intelligence feed endpoints. See [Input Validation (SSRF Prevention)](#input-validation-ssrf-prevention) (lines 549–568).
 
-
 ## Threat Model Summary
 
 pkg-defender's security model rests on these boundaries:

--- a/docs/explanation/security-model.md
+++ b/docs/explanation/security-model.md
@@ -605,6 +605,40 @@ registered in the unified manager registry with full coverage support.*
 | `uv run [script]`      | **Covered** — routes to EXECUTE intent, full pre-install checks run        |
 | `python3.11 -m pip`    | **Not covered** — no `python`/`python3` CLI manager exists; use `pkgd pip` |
 
+## Secure Design Principles
+
+pkg-defender follows established secure design principles throughout its architecture. Each principle is demonstrated by specific implementation decisions documented in this file.
+
+### Fail-Closed
+
+The cooldown engine defaults to **fail-closed**: if a threat cannot be evaluated (e.g., feed unreachable, database corrupted, configuration invalid), the system denies the package by default rather than allowing it. This is the safer default for a security tool. See [Fail-Closed Guarantee](#fail-closed-design) (lines 8–144).
+
+### Least Privilege
+
+Command execution wrappers pass through only explicitly allowed arguments. The tool does not execute arbitrary shell commands or evaluate untrusted input as code. Registry adapters are isolated per package manager, and each adapter has only the permissions necessary for its function.
+
+### Defense in Depth
+
+Threat detection operates at multiple independent layers:
+- **Multiple intelligence feeds** — each threat is cross-referenced against OSV, npm audit, and other feed adapters
+- **Cooldown + blocking** — threats are first assessed (cooldown), then blocked if confirmed
+- **Bypass requires reason** — bypassing a block requires explicit justification, creating an audit trail
+
+See [Cooldown Engine](#fail-closed-design) and [Threat Intelligence](#scoring-model-confidence).
+
+### Secure Defaults
+
+All security features default to the most conservative settings:
+- Cooldown is enabled by default
+- Bypass requires a documented reason
+- Cache timeout defaults to 30 seconds (short window for stale data)
+- No registry adapters are excluded by default
+
+### Input Validation
+
+Domain allowlists prevent SSRF attacks by restricting outbound connections to known threat intelligence feed endpoints. See [Input Validation (SSRF Prevention)](#input-validation-ssrf-prevention) (lines 549–568).
+
+
 ## Threat Model Summary
 
 pkg-defender's security model rests on these boundaries:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ src = ["src"]
 
 [tool.mypy]
 python_version = "3.11"
-python_executable = ".venv/bin/python"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ test = [
     "pytest-timeout>=2.3.0",
     "aioresponses>=0.7.9",
     "coverage[toml]>=7.0",
+    "hypothesis>=6.0",
 ]
 lint = ["ruff>=0.4", "mypy>=1.9", "pre-commit>=4.0", "types-defusedxml>=0.7", "types-python-dateutil>=2.9"]
 
@@ -113,6 +114,7 @@ src = ["src"]
 
 [tool.mypy]
 python_version = "3.11"
+python_executable = ".venv/bin/python"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
@@ -135,6 +137,7 @@ dev = [
     "pytest-timeout>=2.3.0",
     "aioresponses>=0.7.9",
     "coverage[toml]>=7.0",
+    "hypothesis>=6.0",
     # Lint
     "ruff>=0.4",
     "mypy>=1.9",

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Add SPDX-License-Identifier and copyright headers to all Python source files.
+
+Scans every ``.py`` file under ``src/pkg_defender/`` and inserts::
+
+    # Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+    # SPDX-License-Identifier: Apache-2.0
+
+Insertion rules (by file type):
+
+- **Empty file** — header goes at the very beginning of the file,
+  followed by a single newline (no blank-line separator needed).
+- **All non-empty files** — header is the FIRST two lines of the file,
+  followed by exactly one blank line, then the module docstring (if any)::
+
+      # Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+      # SPDX-License-Identifier: Apache-2.0
+
+      \"\"\"Module docstring...\"\"\"
+
+Idempotent — files whose content already contains ``SPDX-License-Identifier``
+are skipped without modification.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+HEADER_LINES = [
+    "# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)",
+    "# SPDX-License-Identifier: Apache-2.0",
+]
+SRC_DIR = pathlib.Path(__file__).resolve().parent.parent / "src" / "pkg_defender"
+HEADER_BLOCK = "\n".join(HEADER_LINES)
+
+
+def _header_is_present(content: str) -> bool:
+    """Return ``True`` if the file already has an SPDX header."""
+    return "SPDX-License-Identifier" in content
+
+
+def add_header(file_path: pathlib.Path) -> bool:
+    """Add the SPDX/copyright header to *file_path*.
+
+    Inserts the header at the top of the file (position 0), followed by
+    exactly one blank line, before any existing content (docstring, code,
+    etc.).
+
+    Returns ``True`` if the file was modified, ``False`` if skipped.
+    """
+    content = file_path.read_text(encoding="utf-8")
+    if _header_is_present(content):
+        return False  # Already has header
+
+    new_content = HEADER_BLOCK + "\n" if not content.strip() else HEADER_BLOCK + "\n\n" + content
+
+    file_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    """Walk all ``.py`` files under ``src/pkg_defender/`` and add headers."""
+    if not SRC_DIR.is_dir():
+        print(f"ERROR: Source directory not found: {SRC_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    py_files = sorted(SRC_DIR.rglob("*.py"))
+    total = len(py_files)
+    modified = 0
+    skipped_already = 0
+    errors: list[str] = []
+
+    for f in py_files:
+        try:
+            if add_header(f):
+                modified += 1
+            else:
+                skipped_already += 1
+        except Exception as exc:
+            rel = f.relative_to(SRC_DIR.parent.parent)
+            errors.append(f"{rel}: {exc}")
+
+    print(f"Total .py files: {total}")
+    print(f"Modified:        {modified}")
+    print(f"Skipped (had):   {skipped_already}")
+    if errors:
+        print(f"Errors:          {len(errors)}")
+        for err in errors:
+            print(f"  ERROR: {err}")
+    else:
+        print("Errors:         0")
+
+    # Post-verification
+    missing_spdx: list[str] = []
+    for f in py_files:
+        content = f.read_text(encoding="utf-8")
+        if "SPDX-License-Identifier" not in content:
+            rel = f.relative_to(SRC_DIR.parent.parent)
+            missing_spdx.append(str(rel))
+
+    if missing_spdx:
+        print(f"\nWARNING: {len(missing_spdx)} files still missing SPDX header:")
+        for m in missing_spdx:
+            print(f"  {m}")
+        sys.exit(1)
+    else:
+        print("\n✓ All files verified: SPDX-License-Identifier present in every file.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pkg_defender/__init__.py
+++ b/src/pkg_defender/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkg-defender — supply chain attack defense CLI."""
 
 from importlib.metadata import PackageNotFoundError

--- a/src/pkg_defender/__pkgd_entry__.py
+++ b/src/pkg_defender/__pkgd_entry__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """PyInstaller binary entry point — breaks circular import bug.
 
 When PyInstaller loads this file as ``__main__``, it does a single canonical

--- a/src/pkg_defender/_http.py
+++ b/src/pkg_defender/_http.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared HTTP fetch utility with retry, backoff with jitter, and configurable error handling."""
 
 from __future__ import annotations

--- a/src/pkg_defender/audit/__init__.py
+++ b/src/pkg_defender/audit/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Audit module for the hooks package.
 
 Exports the audit pipeline and related types for use by the dispatcher.

--- a/src/pkg_defender/audit/bypass_service.py
+++ b/src/pkg_defender/audit/bypass_service.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Service for querying active bypass entries.
 
 Provides a single, centralized implementation for querying active bypasses,

--- a/src/pkg_defender/audit/cooldown.py
+++ b/src/pkg_defender/audit/cooldown.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Cooldown checking — enforces minimum age before installing new packages.
 
 Per spec Section 6 (Step 6) and Section 9.2: Checks the release date against

--- a/src/pkg_defender/audit/errors.py
+++ b/src/pkg_defender/audit/errors.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Structured error types for fail-closed audit pipeline."""
 
 from __future__ import annotations

--- a/src/pkg_defender/audit/types.py
+++ b/src/pkg_defender/audit/types.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared audit types extracted from pipeline for cross-module use."""
 
 from __future__ import annotations

--- a/src/pkg_defender/audit/user_messages.py
+++ b/src/pkg_defender/audit/user_messages.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """User-friendly message templates for shell hook output.
 
 These templates provide consistent, actionable error messages.

--- a/src/pkg_defender/cli/__init__.py
+++ b/src/pkg_defender/cli/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """CLI interface."""
 
 from pkg_defender.cli._ci_detect import get_ci_provider, is_ci_environment

--- a/src/pkg_defender/cli/_ci_detect.py
+++ b/src/pkg_defender/cli/_ci_detect.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """CI environment detection utilities."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/_constants.py
+++ b/src/pkg_defender/cli/_constants.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Constants for version handling with security semantics."""
 
 VERSION_UNSPECIFIED = ""  # User didn't specify a version - check vulnerabilities by package name only

--- a/src/pkg_defender/cli/_dependency_check.py
+++ b/src/pkg_defender/cli/_dependency_check.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Dependency version checking utilities."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/_exit_codes.py
+++ b/src/pkg_defender/cli/_exit_codes.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Domain-specific exit codes for pkg-defender CLI.
 
 Exit code ranges:

--- a/src/pkg_defender/cli/_manager_constants.py
+++ b/src/pkg_defender/cli/_manager_constants.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Manager constants — detection and ecosystem mappings.
 
 This module provides:

--- a/src/pkg_defender/cli/_param_types.py
+++ b/src/pkg_defender/cli/_param_types.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Custom Click ParameterTypes for pkg-defender CLI."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/_progress.py
+++ b/src/pkg_defender/cli/_progress.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Progress indicator utilities for CLI commands.
 
 Supports NO_COLOR environment variable (checked at module init).

--- a/src/pkg_defender/cli/banners.py
+++ b/src/pkg_defender/cli/banners.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """ASCII banner loading for CLI help output."""
 
 import os

--- a/src/pkg_defender/cli/commands/__init__.py
+++ b/src/pkg_defender/cli/commands/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """CLI command modules.
 
 Each module registers commands on the ``cli`` Click group via

--- a/src/pkg_defender/cli/commands/audit.py
+++ b/src/pkg_defender/cli/commands/audit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd audit command."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/audit_logs.py
+++ b/src/pkg_defender/cli/commands/audit_logs.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd audit-logs group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/bypass.py
+++ b/src/pkg_defender/cli/commands/bypass.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd bypass command."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/completion.py
+++ b/src/pkg_defender/cli/commands/completion.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd completion group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/config.py
+++ b/src/pkg_defender/cli/commands/config.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd config group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/daemon.py
+++ b/src/pkg_defender/cli/commands/daemon.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd daemon group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/db.py
+++ b/src/pkg_defender/cli/commands/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd db group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/health.py
+++ b/src/pkg_defender/cli/commands/health.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd health command."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/hooks.py
+++ b/src/pkg_defender/cli/commands/hooks.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd hooks command — shell function generation.
 
 Provides the ``pkgd hooks`` subcommand which detects installed shells and

--- a/src/pkg_defender/cli/commands/intel.py
+++ b/src/pkg_defender/cli/commands/intel.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd intel group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/logs.py
+++ b/src/pkg_defender/cli/commands/logs.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd logs group and subcommands."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/reset.py
+++ b/src/pkg_defender/cli/commands/reset.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd reset command."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/setup.py
+++ b/src/pkg_defender/cli/commands/setup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd setup command."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/commands/status.py
+++ b/src/pkg_defender/cli/commands/status.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """pkgd status command."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/common.py
+++ b/src/pkg_defender/cli/common.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared utilities for CLI command modules.
 
 Extracted from main.py to avoid circular imports when command modules

--- a/src/pkg_defender/cli/dispatcher.py
+++ b/src/pkg_defender/cli/dispatcher.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Manager dispatcher that routes commands to the appropriate package manager adapter."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/exec.py
+++ b/src/pkg_defender/cli/exec.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Exec handoff for pkgd command wrapper.
 
 These functions handle replacing the current Python process with the

--- a/src/pkg_defender/cli/group.py
+++ b/src/pkg_defender/cli/group.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Custom Click group that routes unknown subcommand names to package manager dispatcher."""
 
 from __future__ import annotations

--- a/src/pkg_defender/cli/main.py
+++ b/src/pkg_defender/cli/main.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """CLI entry point — Click commands for pkgd audit, intel, config, health, reset."""
 
 from __future__ import annotations

--- a/src/pkg_defender/config/__init__.py
+++ b/src/pkg_defender/config/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Configuration system."""
 
 from pkg_defender.config.settings import (

--- a/src/pkg_defender/config/settings.py
+++ b/src/pkg_defender/config/settings.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Configuration system — TOML loader, dataclass schema, env var overrides.
 
 Configuration:

--- a/src/pkg_defender/core/__init__.py
+++ b/src/pkg_defender/core/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0

--- a/src/pkg_defender/core/auditor.py
+++ b/src/pkg_defender/core/auditor.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Lock file auditor — scans existing lock files for threats and cooldown violations."""
 
 from __future__ import annotations

--- a/src/pkg_defender/core/checker.py
+++ b/src/pkg_defender/core/checker.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Pre-install checker — queries threat DB and scoring system."""
 
 from __future__ import annotations

--- a/src/pkg_defender/core/parsers.py
+++ b/src/pkg_defender/core/parsers.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Lock file parsers for various package manager formats."""
 
 from __future__ import annotations

--- a/src/pkg_defender/core/registry_domains.py
+++ b/src/pkg_defender/core/registry_domains.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Registry domain allowlist for SSRF attack prevention.
 
 This module provides a hardcoded allowlist of trusted registry domains

--- a/src/pkg_defender/core/scorer.py
+++ b/src/pkg_defender/core/scorer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Threat scorer — confidence weights, severity multipliers, recency decay."""
 
 from __future__ import annotations

--- a/src/pkg_defender/daemon/__init__.py
+++ b/src/pkg_defender/daemon/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Background daemon — periodic feed sync and platform service management."""
 
 from pkg_defender.daemon.runner import (

--- a/src/pkg_defender/daemon/runner.py
+++ b/src/pkg_defender/daemon/runner.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Background daemon runner — periodic feed sync."""
 
 from __future__ import annotations

--- a/src/pkg_defender/daemon/service.py
+++ b/src/pkg_defender/daemon/service.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Platform service generators — launchd (macOS), systemd (Linux), Task Scheduler (Windows)."""
 
 from __future__ import annotations

--- a/src/pkg_defender/db/__init__.py
+++ b/src/pkg_defender/db/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Database layer."""
 
 from pkg_defender.db.schema import CURRENT_SCHEMA_VERSION as CURRENT_SCHEMA_VERSION

--- a/src/pkg_defender/db/schema.py
+++ b/src/pkg_defender/db/schema.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """SQLite schema definitions, database connection management, and CRUD operations."""
 
 from __future__ import annotations

--- a/src/pkg_defender/display.py
+++ b/src/pkg_defender/display.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Display utilities for CLI output using Rich.
 
 Provides block message rendering for all 5 defender scenarios:

--- a/src/pkg_defender/exceptions.py
+++ b/src/pkg_defender/exceptions.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared exception classes for pkg-defender."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/__init__.py
+++ b/src/pkg_defender/intel/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Intelligence feed layer."""
 
 from pkg_defender.intel.aggregator import FeedAggregator, OSVFeedAdapter

--- a/src/pkg_defender/intel/aggregator.py
+++ b/src/pkg_defender/intel/aggregator.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Feed aggregator — concurrent sync across all intelligence feeds."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/base.py
+++ b/src/pkg_defender/intel/base.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Base class for intelligence feed sources."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/extract.py
+++ b/src/pkg_defender/intel/extract.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Package name extraction from unstructured social feed text."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/feeds/__init__.py
+++ b/src/pkg_defender/intel/feeds/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Intelligence feed sources."""
 
 from pkg_defender.intel.feeds.homebrew import HomebrewFeedAdapter

--- a/src/pkg_defender/intel/feeds/_osv_parser.py
+++ b/src/pkg_defender/intel/feeds/_osv_parser.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared OSV vulnerability parsing utilities.
 
 Provides the canonical ``_parse_osv_vuln`` function used by both the OSV feed

--- a/src/pkg_defender/intel/feeds/homebrew.py
+++ b/src/pkg_defender/intel/feeds/homebrew.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Homebrew vulnerability feed using OSV GIT ecosystem.
 
 This module queries the OSV API using the GIT ecosystem with Homebrew

--- a/src/pkg_defender/intel/feeds/osv.py
+++ b/src/pkg_defender/intel/feeds/osv.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """OSV.dev feed source — fetches vulnerability data from the OSV API and data dumps."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/ghsa.py
+++ b/src/pkg_defender/intel/ghsa.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """GitHub Security Advisory (GHSA) feed source."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/mastodon.py
+++ b/src/pkg_defender/intel/mastodon.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Mastodon social feed source — monitors infosec.exchange for security posts."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/npm_advisory.py
+++ b/src/pkg_defender/intel/npm_advisory.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """npm advisory feed — wraps npm audit advisory data."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/ossf_malicious.py
+++ b/src/pkg_defender/intel/ossf_malicious.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenSSF Malicious Packages feed source — fetches known malicious packages.
 
 Single-phase fetch pipeline:

--- a/src/pkg_defender/intel/reddit.py
+++ b/src/pkg_defender/intel/reddit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Reddit feed source — monitors subreddits for supply chain security posts."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/rss_feed.py
+++ b/src/pkg_defender/intel/rss_feed.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """RSS feed source — monitors security blogs for supply chain threats."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/socket.py
+++ b/src/pkg_defender/intel/socket.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Socket.dev feed source — real-time supply chain risk scoring."""
 
 from __future__ import annotations

--- a/src/pkg_defender/intel/x_twitter.py
+++ b/src/pkg_defender/intel/x_twitter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """X/Twitter intelligence feed — BYOK social signal monitor."""
 
 from __future__ import annotations

--- a/src/pkg_defender/logging_filter.py
+++ b/src/pkg_defender/logging_filter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Secret redaction filter for logging."""
 
 import logging

--- a/src/pkg_defender/models/__init__.py
+++ b/src/pkg_defender/models/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Data models for pkg-defender command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/models/command.py
+++ b/src/pkg_defender/models/command.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Data models for command parsing and package management.
 
 This module contains the core data structures used by the pkgd command wrapper

--- a/src/pkg_defender/models/models.py
+++ b/src/pkg_defender/models/models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Data models for pkg-defender."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/__init__.py
+++ b/src/pkg_defender/registry/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Registry adapter layer — unified adapters only."""
 
 from typing import cast

--- a/src/pkg_defender/registry/_bodhi_client.py
+++ b/src/pkg_defender/registry/_bodhi_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Bodhi REST client for RPM update publish-time lookup.
 
 Preferred source for Fedora/EPEL packages. Returns ``date_pushed`` when

--- a/src/pkg_defender/registry/_buildtime_validator.py
+++ b/src/pkg_defender/registry/_buildtime_validator.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """BUILDTIME clamping validator for Fedora 43+ reproducible-builds detection.
 
 This module detects when a package's BUILDTIME (or any source's publish-time

--- a/src/pkg_defender/registry/_koji_client.py
+++ b/src/pkg_defender/registry/_koji_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Koji XML-RPC client for RPM build completion-time lookup.
 
 Used as a tiebreaker when Bodhi has no record. ``getBuild(nvr)`` returns a

--- a/src/pkg_defender/registry/_repodata_client.py
+++ b/src/pkg_defender/registry/_repodata_client.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """YUM/DNF repodata client for per-package ``<time file>`` lookup.
 
 Universal source across all 11 verified RPM distros (YUM-001 §6.1). Returns

--- a/src/pkg_defender/registry/_timestamp.py
+++ b/src/pkg_defender/registry/_timestamp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Centralized timestamp resolution across multiple fallback sources.
 
 Provides a single TimestampResolver class that all ecosystem adapters

--- a/src/pkg_defender/registry/apt.py
+++ b/src/pkg_defender/registry/apt.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """APT registry adapter — package version queries via apt-cache."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/apt_unified.py
+++ b/src/pkg_defender/registry/apt_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified APT adapter — Debian registry lookups + apt command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/base.py
+++ b/src/pkg_defender/registry/base.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Base class for package registry adapters."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/brew.py
+++ b/src/pkg_defender/registry/brew.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Homebrew registry adapter — publish times, version lists, metadata."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/brew_unified.py
+++ b/src/pkg_defender/registry/brew_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Brew adapter — Homebrew registry lookups + brew command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/bun_unified.py
+++ b/src/pkg_defender/registry/bun_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Bun adapter — npm registry lookups + bun command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/bundler_unified.py
+++ b/src/pkg_defender/registry/bundler_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Bundler adapter — RubyGems registry lookups + bundle command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/cargo.py
+++ b/src/pkg_defender/registry/cargo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Cargo (crates.io) registry adapter — publish times, version lists, metadata."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/cargo_unified.py
+++ b/src/pkg_defender/registry/cargo_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Cargo adapter — crates.io registry lookups + cargo command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/composer.py
+++ b/src/pkg_defender/registry/composer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Composer registry adapter — publish times, version lists, metadata.
 
 Composer uses the Packagist API - endpoint verified:

--- a/src/pkg_defender/registry/composer_unified.py
+++ b/src/pkg_defender/registry/composer_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Composer adapter — Packagist registry lookups + composer command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/conda.py
+++ b/src/pkg_defender/registry/conda.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Conda registry adapter — publish times, version lists, metadata.
 
 This adapter uses ``conda search`` to query the conda-forge channel

--- a/src/pkg_defender/registry/conda_unified.py
+++ b/src/pkg_defender/registry/conda_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Conda adapter — conda-forge registry lookups + conda command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/dnf.py
+++ b/src/pkg_defender/registry/dnf.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """DNF registry adapter — YUM alias (DNF is a fork of YUM, same RPM ecosystem).
 
 DNFAdapter inherits from YUMAdapter — the publish-time cascade

--- a/src/pkg_defender/registry/dnf_unified.py
+++ b/src/pkg_defender/registry/dnf_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified DNF adapter — YUM alias in the unified registry.
 
 DnfUnifiedAdapter inherits from YumUnifiedAdapter — DNF uses the

--- a/src/pkg_defender/registry/flags.py
+++ b/src/pkg_defender/registry/flags.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Value flags for all supported package managers.
 
 VALUE_FLAGS are flags that consume the NEXT argument as their value.

--- a/src/pkg_defender/registry/gem_unified.py
+++ b/src/pkg_defender/registry/gem_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified gem adapter — RubyGems registry lookups + gem command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/npm.py
+++ b/src/pkg_defender/registry/npm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """npm registry adapter — publish times, version lists, metadata."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/npm_unified.py
+++ b/src/pkg_defender/registry/npm_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified npm adapter — npm registry lookups + npm command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/parsing.py
+++ b/src/pkg_defender/registry/parsing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Version and package reference parsing functions for each ecosystem.
 
 These functions parse package references from raw command-line strings

--- a/src/pkg_defender/registry/pipenv_unified.py
+++ b/src/pkg_defender/registry/pipenv_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Pipenv adapter — Pipenv command parsing + PyPI registry lookups."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/pnpm_unified.py
+++ b/src/pkg_defender/registry/pnpm_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified pnpm adapter — npm registry lookups + pnpm command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/poetry_unified.py
+++ b/src/pkg_defender/registry/poetry_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Poetry adapter — Poetry command parsing + PyPI registry lookups."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/pypi.py
+++ b/src/pkg_defender/registry/pypi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """PyPI registry adapter — publish times, version lists, metadata."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/pypi_unified.py
+++ b/src/pkg_defender/registry/pypi_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified PyPI adapter — combines PyPIAdapter registry lookups with PipAdapter command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/rubygems.py
+++ b/src/pkg_defender/registry/rubygems.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """RubyGems registry adapter — publish times, version lists, metadata."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/uv_unified.py
+++ b/src/pkg_defender/registry/uv_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified uv adapter — uv command parsing + PyPI registry lookups."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/yarn_unified.py
+++ b/src/pkg_defender/registry/yarn_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified Yarn adapter — npm registry lookups + yarn command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/registry/yum.py
+++ b/src/pkg_defender/registry/yum.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """YUM/DNF registry adapter — package version queries via dnf repoquery + Bodhi/Koji/repodata publish-time cascade.
 
 The publish-time cascade delegates to three specialized clients (Phase 0 modules):

--- a/src/pkg_defender/registry/yum_unified.py
+++ b/src/pkg_defender/registry/yum_unified.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Unified YUM adapter — YUM registry lookups + yum command parsing."""
 
 from __future__ import annotations

--- a/src/pkg_defender/shells/__init__.py
+++ b/src/pkg_defender/shells/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shell detection and completion installation utilities.
 
 This module provides utilities for detecting the user's shell and installing

--- a/src/pkg_defender/shells/detect.py
+++ b/src/pkg_defender/shells/detect.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Shell detection utilities.
 
 This module provides functions for detecting the user's shell from environment

--- a/src/pkg_defender/shells/install.py
+++ b/src/pkg_defender/shells/install.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Completion script installation utilities.
 
 This module provides functions for installing completion scripts for various

--- a/src/pkg_defender/version.py
+++ b/src/pkg_defender/version.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)
+# SPDX-License-Identifier: Apache-2.0
+
 """Version comparison utilities — single source of truth.
 
 All version comparison in pkg-defender flows through this module.

--- a/tests/unit/core/test_scoring_properties.py
+++ b/tests/unit/core/test_scoring_properties.py
@@ -1,0 +1,163 @@
+"""Property-based tests for threat scoring invariants.
+
+Uses hypothesis for randomized/fuzzing-style testing of numeric
+invariants in the scoring model.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from pkg_defender.core.scorer import get_display_severity, score_threat
+from pkg_defender.models.models import ThreatRecord
+
+settings.register_profile("ci", max_examples=100)
+settings.load_profile("ci")
+
+VALID_SEVERITIES = {"CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"}
+SEVERITY_ORDER = {"UNKNOWN": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+SOCIAL_SOURCES = {"mastodon", "reddit", "x_twitter"}
+
+_SOURCE_STRATEGY = st.sampled_from(
+    [
+        "osv",
+        "ghsa",
+        "socket",
+        "npm_advisory",
+        "ossf_malicious",
+        "homebrew_osv",
+        "rss",
+        "mastodon",
+        "reddit",
+        "x_twitter",
+    ]
+)
+
+_SEVERITY_STRATEGY = st.sampled_from(["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"])
+
+_ECOSYSTEM_STRATEGY = st.sampled_from(["npm", "pypi", "cargo", "gem", "go"])
+# Shared base for ThreatRecord builds — provides only the fields that
+# score_threat actually reads (severity, source, first_seen) plus the
+# required positional fields (id, ecosystem).
+_THREAT_BUILD_KWARGS: dict[str, Any] = {
+    "id": st.text(min_size=1, max_size=64),
+    "ecosystem": _ECOSYSTEM_STRATEGY,
+    "severity": _SEVERITY_STRATEGY,
+    "source": _SOURCE_STRATEGY,
+    "first_seen": st.datetimes(),
+}
+
+
+# ---------------------------------------------------------------------------
+# get_display_severity  — property-based tests
+# ---------------------------------------------------------------------------
+class TestGetDisplaySeverityProperties:
+    """Property-based tests for get_display_severity invariants."""
+
+    @given(st.floats(min_value=0.0, max_value=1.0))
+    def test_output_is_always_valid_severity(self, score: float) -> None:
+        """Output is always one of the valid severity labels."""
+        assert get_display_severity(score) in VALID_SEVERITIES
+
+    @given(
+        st.floats(min_value=0.0, max_value=1.0),
+        st.floats(min_value=0.0, max_value=1.0),
+    )
+    def test_display_severity_is_monotonic(self, s1: float, s2: float) -> None:
+        """Higher scores never produce a lower severity label (monotonic)."""
+        if s2 >= s1:
+            sev1 = SEVERITY_ORDER[get_display_severity(s1)]
+            sev2 = SEVERITY_ORDER[get_display_severity(s2)]
+            assert sev2 >= sev1, f"s1={s1} -> {get_display_severity(s1)}, s2={s2} -> {get_display_severity(s2)}"
+
+
+# ---------------------------------------------------------------------------
+# score_threat — property-based tests
+# ---------------------------------------------------------------------------
+class TestScoreThreatProperties:
+    """Property-based tests for score_threat invariants."""
+
+    @given(
+        st.builds(ThreatRecord, **_THREAT_BUILD_KWARGS),
+        st.integers(min_value=0, max_value=10),
+    )
+    def test_score_always_between_zero_and_one(
+        self,
+        threat: ThreatRecord,
+        corroboration_count: int,
+    ) -> None:
+        """Final score is always in [0.0, 1.0] regardless of inputs."""
+        now = datetime.now(UTC)
+        result = score_threat(threat, "exact", max(corroboration_count, 1), now)
+        assert 0.0 <= result.final_score <= 1.0, (
+            f"Score {result.final_score} out of range [0, 1] "
+            f"(severity={threat.severity}, source={threat.source}, "
+            f"corrob={corroboration_count})"
+        )
+
+    @given(
+        st.builds(ThreatRecord, **_THREAT_BUILD_KWARGS),
+        st.integers(min_value=0, max_value=10),
+    )
+    def test_display_severity_matches_get_display_severity(
+        self,
+        threat: ThreatRecord,
+        corroboration_count: int,
+    ) -> None:
+        """display_severity on ScoredThreat matches get_display_severity(final_score)."""
+        now = datetime.now(UTC)
+        result = score_threat(threat, "exact", max(corroboration_count, 1), now)
+        expected = get_display_severity(result.final_score)
+        assert result.display_severity == expected, (
+            f"display_severity={result.display_severity} != "
+            f"get_display_severity({result.final_score})={expected} "
+            f"(severity={threat.severity}, source={threat.source})"
+        )
+
+    @given(
+        st.builds(
+            ThreatRecord,
+            **{
+                **_THREAT_BUILD_KWARGS,
+                "severity": st.just("CRITICAL"),
+                "source": st.sampled_from(["mastodon", "reddit", "x_twitter"]),
+            },
+        ),
+        st.integers(min_value=0, max_value=10),
+    )
+    def test_social_critical_never_exceeds_medium(
+        self,
+        threat: ThreatRecord,
+        corroboration_count: int,
+    ) -> None:
+        """Social sources with CRITICAL severity never exceed MEDIUM display."""
+        now = datetime.now(UTC)
+        result = score_threat(threat, "exact", max(corroboration_count, 1), now)
+        severity_order = {"UNKNOWN": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+        assert severity_order[result.display_severity] <= severity_order["MEDIUM"], (
+            f"Social source {threat.source} with CRITICAL severity "
+            f"produced display_severity={result.display_severity} "
+            f"(score={result.final_score})"
+        )
+
+    @given(
+        st.builds(ThreatRecord, **_THREAT_BUILD_KWARGS),
+        st.integers(min_value=1, max_value=9),
+    )
+    def test_higher_corroboration_never_lowers_score(
+        self,
+        threat: ThreatRecord,
+        c_low: int,
+    ) -> None:
+        """Higher corroboration_count never produces a lower score (monotonic)."""
+        c_high = c_low + 1
+        now = datetime.now(UTC)
+        score_low = score_threat(threat, "exact", c_low, now).final_score
+        score_high = score_threat(threat, "exact", c_high, now).final_score
+        assert score_high >= score_low, (
+            f"corrob={c_high} gave score={score_high} < "
+            f"corrob={c_low} gave score={score_low} "
+            f"(severity={threat.severity}, source={threat.source})"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -431,6 +431,67 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.156.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/83/8dbe89bdb8c6f25a7a52e7898af6d82fe35dfef08e5c702f6e33231ce6c6/hypothesis-6.156.6.tar.gz", hash = "sha256:96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc", size = 476304, upload-time = "2026-07-10T20:56:49.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/dc/0c2a851f06c91d5ac9ef0f3b9615efc1ed650411d2eee23b6334f491c85e/hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875", size = 747998, upload-time = "2026-07-10T20:56:16.311Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f8/59203ca978ab51595d12d6bc7e7a63300d7373431ab42ca3f1742e45db68/hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843", size = 743073, upload-time = "2026-07-10T20:55:36.825Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d8/86a0023740434098d1b187a62bd5f99b198f098fb43e7fc58342283a8270/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6", size = 1070169, upload-time = "2026-07-10T20:55:49.47Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/82/673453915fd0c67673f35a4876ba88f48c621335f293f3537d77b27d4286/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424", size = 1121760, upload-time = "2026-07-10T20:55:53.502Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c3/3a5557f52912f2fecc6ed59642dcf80dd8e89d0d9664502b68e23d66bf3d/hypothesis-6.156.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a922eedcd8618f9c2e17b79fa7b3f3f0b2df34e201958611cc3f0f46cca33c10", size = 1111440, upload-time = "2026-07-10T20:55:43.054Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a6/ae636d4ca7f996a1ccb4b3d5997d949f1718fba52b01559b3ab53b237b3f/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5291bd33c4704d274d7c214d5c200e77f372a06644f5cbbe96dcbe53cb2fbf10", size = 1244944, upload-time = "2026-07-10T20:55:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/79/c425d22d734be0268ca60d120c6296299e4220a1783cb1a4cc76232807bb/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55f3ec50161b4a95bae63bff2b5166e45935b493013d3be30ede279bf6192318", size = 1288808, upload-time = "2026-07-10T20:56:06.249Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3a/cc9f479d22cbdd36ddfc55a978378eddadd183b09339ebdb81be33bb18e7/hypothesis-6.156.6-cp310-abi3-win32.whl", hash = "sha256:e96570ca5cdd9a5f2ff9e80a6fb2fd5420ebf33b833d7de5b09b6ebb26a3eb6c", size = 634868, upload-time = "2026-07-10T20:55:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/89/2008d287289841a936456cb13443ca89d88da6e4527d611d482e9544164d/hypothesis-6.156.6-cp310-abi3-win_amd64.whl", hash = "sha256:32710718c22fe8c5571464e898bb87d282837b02617d6ad68130abf7cb4843cb", size = 640382, upload-time = "2026-07-10T20:55:30.634Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/e4a0796190d8089e85f06731e21fdddd7e8edd3a4e562101527a048e21c4/hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5baec7943a14d106e982121dd4f74cfc5ef45e37c17f94fe49338d3d1377f38c", size = 748988, upload-time = "2026-07-10T20:56:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a2/4a789b286cd2cced31992e1f683036b51dd6909b934ea007ffb43aa3a32f/hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5f519905ddeb10e23b8ba2c254541a5b1a8f146fe0551be94d972f4a77226f4", size = 743754, upload-time = "2026-07-10T20:56:09.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f7/3dd36c1c03d24ae3ffc3c5b0eca8cc4ae90c07abc320f76509eceb37019a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c108655960b58ded3ca71b2dc5c69fb2ba7e9c723aeb6106facec3892d09087", size = 1070732, upload-time = "2026-07-10T20:56:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/57/51/befc4b816b471078034a875eb1ef69e0411ab84bcce582b4be173258785a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c8d37bebb6924729bc0bbf5852689df568842948abe4d93dd0ad3377adf76fa", size = 1121988, upload-time = "2026-07-10T20:56:07.676Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b7/a796f5e3e4b7cb911ff346008d49720296d1f4073490b8bc1cce6b3fbb07/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:74137bef6d502305c3648b2ed1a9bb4bc05fb1025e96b30a2c092204c40fe097", size = 1245596, upload-time = "2026-07-10T20:55:50.662Z" },
+    { url = "https://files.pythonhosted.org/packages/37/65/849c4cba44a6f6cc888fd931124429b24180234ccc4883abab8cad5fcfcb/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5e0afdf79cceed20fcf0a9fb80d4064a9b2b53d4d4eecbac0e21208a13f5a31b", size = 1289172, upload-time = "2026-07-10T20:55:58.915Z" },
+    { url = "https://files.pythonhosted.org/packages/13/03/7106a110df29eb631d66776e8aa8128f82f04a9dd2b6b22b612e6025e3a2/hypothesis-6.156.6-cp311-cp311-win_amd64.whl", hash = "sha256:84dc89caaf741a02f904ca7bd02b1af99650c75552868162290208aeecb70858", size = 640222, upload-time = "2026-07-10T20:56:10.396Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/45/9f009005b9c796f4a40424484ac7e70847bc088456fd940a937f96bb4b6d/hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf", size = 748844, upload-time = "2026-07-10T20:56:38.036Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2f/4d852bb8a9c73a68b18eca9b5b085285282122166e158f4d2a477639bfee/hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58", size = 741936, upload-time = "2026-07-10T20:55:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/74/89/b9968070ae042f9bf3149bb6ba6399d5f28f452e0fb7f638cafc69ff0b9a/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd", size = 1069749, upload-time = "2026-07-10T20:56:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a9/753806f5292b40aeab1d269e408e3a7e85be3c0d88828fb78ab4a34d6626/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d", size = 1120983, upload-time = "2026-07-10T20:56:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/85/88/8386d064d680be27e936eba94f1448bc93ef6fa05473ee5034139f1c4284/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08796b674c0b31a5dd4119b2173823390055921588d13eb77324e861b00fd7f8", size = 1243911, upload-time = "2026-07-10T20:55:54.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8c/7524c1e5279e7728eb47c99f2357cbc5f08ae92e9bce49bf50118b53f9c9/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4ca8cc26ea2d31d22cf7710e92951cfaa921f0f8aa1b6db33a5176335f583a4f", size = 1287806, upload-time = "2026-07-10T20:56:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b3/c347ad913e1c5f2988956fe17826c0400b4ce470b973e6c248e97b6a0acf/hypothesis-6.156.6-cp312-cp312-win_amd64.whl", hash = "sha256:c3363d3fb8015594636689572510bb6090602d8e8e838a5693c2d52d3b5b09d8", size = 637679, upload-time = "2026-07-10T20:55:39.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5d/9583fe153573523dac27226c89e041a86ad4aeeae08c868160cbb93d39d2/hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:59a8def90d9a5a9b67e1ac529e903a2363ceb6cf873c209da6b4284c5daab671", size = 749264, upload-time = "2026-07-10T20:56:46.118Z" },
+    { url = "https://files.pythonhosted.org/packages/86/35/e4113d06769b544f0fb77ffea9195b598b4c56a298905c21fd47c4eed388/hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c574c3224563d730848bc5d1ef1683c4f83993400c0167899fe328f4bfcd4725", size = 742095, upload-time = "2026-07-10T20:56:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5c/a47666ede10384e8978722cade7ab96a42df71d2ab577317092d0fed7c8a/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01bb8270c46b3ef53b0c2d23ff613ea506d609d06f936d823ea57c58b66b05f7", size = 1069917, upload-time = "2026-07-10T20:56:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/79/93/75f6057dadd9dc0134f37c08d5d14d04d3cd7374debbcb0cc4569c6712f1/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4ea6559c13606e13b645927f2e0906e52b5ac5d99b40d3abaaeb2e8c7ceeb75", size = 1121204, upload-time = "2026-07-10T20:55:52.008Z" },
+    { url = "https://files.pythonhosted.org/packages/62/87/308efef08bc60d1e673d035e8ca8e9663f4b6b3ba519c3cdebf6583c2b76/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d47054d0230f0dd9b6868fc030126c7a6c25527144272ff376cc4e9c39f7540", size = 1244168, upload-time = "2026-07-10T20:55:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/66/de8fff5bd9a40a4056dafbe7f904887ef12632282bbbac90f1977c30dd3b/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:050c8c0815f88d47dd0875a92698d20d61639b7b721ee043a6d687c7f14ff7d8", size = 1288127, upload-time = "2026-07-10T20:56:00.541Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8d/794fb26e1fd3ff004978f8f18b7aa7e1c2270ba72e1f977b987a812064f8/hypothesis-6.156.6-cp313-cp313-win_amd64.whl", hash = "sha256:f0d73edab7b8a0051b3634f2d04d62b7e7282f8f274963b11188ee4957d672ef", size = 637954, upload-time = "2026-07-10T20:56:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/5b4b27984cb43c60e95f570b069660335dad34cb67f7d226017c5d35d31e/hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:34a70a7b8226e34d658072d8fb81d03f97f0a75ceb536329a321b94ce2232fd6", size = 749312, upload-time = "2026-07-10T20:55:46.902Z" },
+    { url = "https://files.pythonhosted.org/packages/31/11/709cceffc28666c9d4cb75ffc6df5ce30db8c7dd5cc2c8b38a2fd837427f/hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f1969646beead7d8cf6a2537d2765af89d73056e2cb218e7fae92b83802250a3", size = 742332, upload-time = "2026-07-10T20:56:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/cfc79b13d8dd3cd6de6b9df921c557efe8528a9c90a3a7cd93b37188d57e/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbc2ec7b7d905e6b6ec1635f6340bfa52aaab718101c59f052bc012a6b486cd8", size = 1070109, upload-time = "2026-07-10T20:55:48.244Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/1da4def1f006b5ad01187ff96379e24c37439d659ec10c3e944c03436c0f/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9367ae25dfa6dc1af37904785e43c4f8fe1c4118cafdc2f06514154fbdd90992", size = 1121528, upload-time = "2026-07-10T20:56:39.665Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/744e4f5e3d635dea20dbedf3fa486e2a6fa5210e0a52a0d5c4da56babd84/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:455f09107ec07c78f2a83cb8fc19e23879c9d51cdc831de6f9cb6ec4059cb9af", size = 1244690, upload-time = "2026-07-10T20:56:31.854Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8a/42252fcd5e521d140dac532f29c2a13ca8f22908cb545ffdd64b5e225680/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c76634c45a3ceee4c4fdfed39aebd08b8b822ec8b0c556877ef82846fd777730", size = 1288519, upload-time = "2026-07-10T20:56:03.429Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e7/176df9e47cf583d2b8d234b78c0aac3a47075ad5d147e60b2c21a1338bb1/hypothesis-6.156.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:eb7e9f8343bc6b948937e6ec12e6879ed25a17b53ceccbd2b84adadd3d511698", size = 586452, upload-time = "2026-07-10T20:56:22.285Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/75/2c8a0411bbe76429f3ae738ef9a00107201bf6146d9534350014ce369d98/hypothesis-6.156.6-cp314-cp314-win_amd64.whl", hash = "sha256:f9631cd604ae6032c3edf99160dc1b9e33873f2e52762246b24f07fb758652ae", size = 637774, upload-time = "2026-07-10T20:56:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/22/8115005e9aa72c8d63d90e9db5e0b8425fd8950fbc5d6e332805d4d32c9e/hypothesis-6.156.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1f81163d36d3763b09ffaef7c3a71e88174ca3e6816201fca9d1d159f448fdb5", size = 747428, upload-time = "2026-07-10T20:56:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c2/66bfe9337f4a4b1f7754ee6d01d950280152a81d0d797e6c1d9eb0909750/hypothesis-6.156.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:556b905767e36147918634a64356aa05d8c956576f00aee01eb351678f193908", size = 740889, upload-time = "2026-07-10T20:55:57.656Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3b/69f45af2d4f0950b7d1af3cdbdd800b88a6c2370331481eda79d6171fbe3/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f2604b28d16d696aaaf4954d20f907b27e54034df98e64746a20c74c319f03", size = 1069270, upload-time = "2026-07-10T20:56:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/43/6b2549885da08f5e50ba34fb8e0d0a60b2f190ffd516fac220f8db5b5869/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe012ad66dbe7b8e8ddef6f6992ab1b36719ea64430c2bf1ff7135521052a15", size = 1120409, upload-time = "2026-07-10T20:55:34.551Z" },
+    { url = "https://files.pythonhosted.org/packages/70/97/745c778c3eb29befa2367b1ded8437eecfbbe6932359d0f831275bc32170/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfa3c7b758f7278081c6bfec5f89b43c4eb075c0c9eb095323f7a9eb019b513", size = 1243111, upload-time = "2026-07-10T20:56:17.83Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d7/c5ec6a442dc9b822f47064bda4b6d3e739dccdd1c5bf44c9a57fb6136830/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d0db1f4573800c618773622f03cb6533bb3377430ef938c9476ba10c39d22591", size = 1287262, upload-time = "2026-07-10T20:56:23.749Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0c/c134d61710e14b68b010215dcf6bd57d2ec05cd169dff8bfab8fefc2d410/hypothesis-6.156.6-cp314-cp314t-win_amd64.whl", hash = "sha256:38cd0c4a7b9f809f1e23a4d15adfa9c5d99869b9afc327350a5e563350b78e48", size = 637862, upload-time = "2026-07-10T20:56:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9c/b94f3a31665527b6181616b72990fcf8d6d5fa82b4187aab104ab5f548f0/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8893b4da90e06828846c1b100c3414a7729d047a020d854c0899ae9339df0e70", size = 749575, upload-time = "2026-07-10T20:55:29.371Z" },
+    { url = "https://files.pythonhosted.org/packages/21/74/dcf695f79f526543ae5d0f8c1325508e9fe990a996c0e0853129a9a5d81d/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b7fc0b7df9b28d028e4cc295b2ac8fbbbc22e090a23382c92fff5e37696be74f", size = 744351, upload-time = "2026-07-10T20:56:36.46Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d3/5bff4c55c6995a6c43f66ec8e5866b56e34f03837fd0be0e4922f3bab168/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38ed3178526382d392d04ad699ad7a2e53845e521a09d40f1cbbc1e1ff63ba48", size = 1070916, upload-time = "2026-07-10T20:56:19.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/af/5ed42117a69221ea118caaff933d8212039a0ac0bc15afa915635f13984c/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ad94e28aabf4db0d479297d43b8a2a01e7caaa9bdfccfdac7a4a3717e05b993", size = 1122625, upload-time = "2026-07-10T20:56:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d3/02499badc6e3f3e980941021edf5fd780c895d8d08c9015e78516340ed83/hypothesis-6.156.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:983a5cfd955994bffc7eb02976241f7a1f3c2d94dbc3389430c45858fa5c1ae0", size = 640823, upload-time = "2026-07-10T20:55:45.461Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -782,6 +843,7 @@ lint = [
 test = [
     { name = "aioresponses" },
     { name = "coverage", extra = ["toml"] },
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -793,6 +855,7 @@ test = [
 dev = [
     { name = "aioresponses" },
     { name = "coverage", extra = ["toml"] },
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -813,6 +876,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "defusedxml", specifier = ">=0.7,<1.0" },
     { name = "feedparser", specifier = ">=6.0,<7.0" },
+    { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "mypy", marker = "extra == 'lint'", specifier = ">=1.9" },
     { name = "packaging", specifier = ">=23.0,<24.0" },
     { name = "platformdirs", specifier = ">=4.0,<5.0" },
@@ -836,6 +900,7 @@ provides-extras = ["test", "lint"]
 dev = [
     { name = "aioresponses", specifier = ">=0.7.9" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.0" },
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "mypy", specifier = ">=1.9" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -1168,6 +1233,15 @@ name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
<!-- PR TITLE: Use Conventional Commits: <type>(<scope>): <description>
     Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
     Example: feat(cli): add --json flag to audit command
     See CONTRIBUTING.md for the full specification. -->

<!-- TARGET BRANCH: Feature, fix, and doc branches → `develop`. Hotfixes → `main`.
     See CONTRIBUTING.md for branching strategy. -->

## Summary

Prepare pkg-defender for OpenSSF Best Practices Badge certification (Silver tier) by implementing SAST scanning, SLSA provenance, attestations, SPDX licensing, property-based testing, governance documentation, DCO enforcement, and secure design documentation.

Target: `develop`

---

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔒 Security fix
- [ ] ♻️ Refactor (no functional changes)
- [x] 📖 Documentation update
- [x] 🧪 Tests only
- [x] 🏗️ Build / CI / dependency update
- [ ] ⚡ Performance improvement
- [ ] 🎨 Style (formatting, no logic change)
- [x] 🧹 Chore (formatting, renaming, cleanup)

---

## Motivation and Context

The OpenSSF Best Practices Badge is a widely-recognized security certification for open source projects. Achieving Silver demonstrates that PKG-Defender follows established secure development, testing, and governance practices. This PR implements all changes needed to meet the Silver criteria, with the final submission step performed after merge-to-main.

---

## Implementation Notes

### Phase A — SAST & Scorecard
- New `.github/workflows/codeql.yml` — CodeQL analysis on push/PR to main/develop + weekly
- New `.github/workflows/scorecard.yml` — OpenSSF Scorecard analysis on push to main + weekly, with `publish_results: true`

### Phase BC — SLSA & Attestations
- `release.yml`: scoped default permissions to `contents: read` (least privilege)
- New `provenance` job generating SLSA Build Level 3 provenance for sdist/wheel
- Binary artifact attestations via `actions/attest-build-provenance`
- Docker image provenance attestation pushed to GHCR
- Per-job permissions scoped to minimum required

### Phase D — SPDX Licensing
- `# Copyright (c) 2026 DIVISION 7 | MI-7 (@divisionseven)` and `# SPDX-License-Identifier: Apache-2.0` headers added to all 113 source files under `src/pkg_defender/`
- `scripts/add_spdx_headers.py` for automated header management

### Phase E — Property-Based Testing
- New `hypothesis>=6.0` dependency (test/dev only)
- `tests/unit/core/test_scoring_properties.py` with 6 invariant tests covering score bounds, display severity monotonicity, social-critical thresholds, and corroboration behavior
- Fixed mypy configuration to use `python_executable = ".venv/bin/python"` so the venv's Python interpreter (and its site-packages, including hypothesis with full type stubs) is used for type checking — eliminates all import-not-found and untyped-decorator errors without inline suppressions

### Phase F — Governance & DCO
- New `GOVERNANCE.md` — project governance document defining maintainer model, roles, decision-making, promotion path, and conflict resolution
- DCO (Developer Certificate of Origin) section added to `CONTRIBUTING.md` with sign-off instructions and DCO GitHub App reference

### Phase G — Secure Design Principles
- New `## Secure Design Principles` section in `docs/explanation/security-model.md` covering fail-closed, least privilege, defense in depth, secure defaults, and input validation — each referencing existing evidence in the same document

### Phase H — Badges
- Added OpenSSF Scorecard badge (shields.io, matching existing convention); auto-populates after first workflow run on `main`
- Added OpenSSF Best Practices badge (placeholder `<PROJECT_ID>`) — activated after registration
- Updated platforms badge to `macOS ARM64/x86_64 | Linux x86_64 | Windows x86_64`

### Phase I — Changelog
- `CHANGELOG.md` updated with all changes under `[Unreleased]`

---

## Testing

- [x] I have added tests that cover the changes in this PR
- [x] All existing tests pass locally (`pytest --cov-fail-under=90`)
- [x] I have run the e2e gate test locally (`pytest tests/integration/test_smoke_e2e.py --tb=short -q`)
- [x] I have tested this manually (describe what you did below)

**Manual testing performed:**
- Full test suite: 4478 passed, 0 failed, 91.25% coverage
- `mypy --strict`: 0 errors across 283 source files
- All 6 hypothesis property-based tests pass
- Workflow YAML validated (no `runs-on` + `uses` conflicts, correct permission scoping)

---

## Checklist

- [x] My code follows the project's style guidelines (passes `ruff check .` and `ruff format --check .`)
- [x] My code passes type checking (`mypy .`)
- [x] My changes maintain or improve code coverage (`pytest --cov-fail-under=90`)
- [ ] My CLI changes use the correct exit codes defined in `docs/reference/exit-codes.md`
- [x] I have updated documentation as needed (README, docstrings, CHANGELOG)
- [x] I have updated `CHANGELOG.md` with a brief entry under `[Unreleased]`
- [x] My changes do not introduce new dependencies without discussion
- [x] Any new dependencies are pinned appropriately in `pyproject.toml`
- [x] I am aware that the dependency review workflow (`.github/workflows/dependency-review.yml`) runs automatically on PRs
- [x] I have reviewed my own diff before requesting review

---

## Screenshots / Output

```
# Final verification:
$ pytest --cov-fail-under=90
4478 passed, 0 failed
Coverage: 91.25%

$ make check
ruff check src/
All checks passed!
ruff format --check src/
113 files already formatted
mypy src/
Success: no issues found in 113 source files
uv run pytest
[...test output]
4478 passed in 276.89s (0:04:36)
```

---

## Breaking Changes

None.

---

## Related Issues / PRs

None.