### PR TITLE
docs(readme): fix OpenSSF Scorecard badge to show correct score

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,8 +962,7 @@ above with full transparency audit links.
 [language-pkgs-badge-icon]: https://img.shields.io/badge/Language_Packages-npm_%7C_PyPI_%7C_Cargo_%7C_RubyGems_%7C_Packagist-black?
 [system-pkgs-badge-icon]: https://img.shields.io/badge/System_Packages-Homebrew_%7C_APT_%7C_Yum_%7C_DNF_%7C_Conda-black?
 [ossf-bp-badge-icon]: https://img.shields.io/badge/openssf%20best%20practices-passing-black?label=OpenSSF%20Best%20Practices
-[scorecard-badge-icon]: https://img.shields.io/ossf-scorecard/github.com/divisionseven/pkg-defender?color=black&label=OpenSSF%20Scorecard
-
+[scorecard-badge-icon]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fdivisionseven%2Fpkg-defender&query=%24.score&label=OpenSSF%20Scorecard&color=black
 <!-- Header Badge Links -->
 
 [license-badge-link]: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
## Summary

Fixes stale OpenSSF Scorecard badge on README. Badge was reading `img.shields.io/ossf-scorecard` (which hits deprecated `api.securityscorecards.dev` weekly scan, age 5.2 days, score 8.4, renders as `8`) while the viewer and `publish_results` API `api.scorecard.dev` is at `8.6` (2026-08-26, commit 4c5d2ae). Switch README to dynamic JSON badge that reads `api.scorecard.dev` directly so it matches the viewer.


---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔒 Security fix
- [ ] ♻️ Refactor (no functional changes)
- [x] 📖 Documentation update
- [ ] 🧪 Tests only
- [ ] 🏗️ Build / CI / dependency update
- [ ] ⚡ Performance improvement
- [ ] 🎨 Style (formatting, no logic change)
- [ ] 🧹 Chore (formatting, renaming, cleanup)

---

## Motivation and Context

Badge in README said `8` but clicking through shows `8.6`. `api.securityscorecards.dev` (old, weekly scan) is at `8.4` on 2026-08-24 and `img.shields.io/ossf-scorecard` fetches from there. `api.scorecard.dev` (new, `publish_results: true` in `.github/workflows/scorecard.yml`) is at `8.6` on 2026-08-26 and is what `scorecard.dev/viewer` displays. Even `https://api.scorecard.dev/.../badge` 302s back to shields old route, so it stays at `8`. Verified live: old badge SVG = `8`, new API JSON = `8.6`, new dynamic badge SVG = `8.6`.

---

## Implementation Notes

Single line in `README.md:965`:

- from: `https://img.shields.io/ossf-scorecard/github.com/divisionseven/pkg-defender?color=black&label=OpenSSF%20Scorecard`
- to: `https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.scorecard.dev%2Fprojects%2Fgithub.com%2Fdivisionseven%2Fpkg-defender&query=%24.score&label=OpenSSF%20Scorecard&color=black`

Keeps black styling/label, adds `query=$.score` with one decimal, bypasses deprecated domain and its cache. No code changes.

---

## Testing

- [ ] I have added tests that cover the changes in this PR
- [ ] All existing tests pass locally (`pytest --cov-fail-under=90`)
- [ ] I have run the e2e gate test locally (`pytest tests/integration/test_smoke_e2e.py --tb=short -q`)
- [x] I have tested this manually (describe what you did below)

**Manual testing performed:**
- `curl api.scorecard.dev/projects/github.com/divisionseven/pkg-defender` → `8.6`
- `curl api.securityscorecards.dev/projects/github.com/divisionseven/pkg-defender` → `8.4`
- `curl img.shields.io/ossf-scorecard/...` → SVG `8`
- `curl img.shields.io/badge/dynamic/json?url=...api.scorecard.dev...` → SVG `8.6`
- Verified new badge URL in README renders `8.6` locally

---

## Checklist

- [x] My code follows the project's style guidelines (passes `ruff check .` and `ruff format --check .`)
- [x] My code passes type checking (`mypy .`)
- [x] My changes maintain or improve code coverage (`pytest --cov-fail-under=90`)
- [x] My CLI changes use the correct exit codes defined in `docs/reference/exit-codes.md`
- [x] I have updated documentation as needed (README, docstrings, CHANGELOG)
- [ ] I have updated `CHANGELOG.md` with a brief entry under `[Unreleased]` <!-- not needed for badge doc fix, keep unchecked -->
- [x] My changes do not introduce new dependencies without discussion
- [x] Any new dependencies are pinned appropriately in `pyproject.toml`
- [x] I am aware that the dependency review workflow (`.github/workflows/dependency-review.yml`) runs automatically on PRs
- [x] I have reviewed my own diff before requesting review

---

## Screenshots / Output

Before: badge SVG 8 (shields old API)
After: badge SVG 8.6 (dynamic json via api.scorecard.dev) ;  curl confirms 8.6 title/text

--

Breaking Changes

None. README badge only.

--

Related Issues / PRs

• Shields service ossf-scorecard.service.js:42 still uses api.securityscorecards.dev (deprecated)
• api.scorecard.dev/.../badge currently 302s to img.shields.io/ossf-scorecard ;  tracked upstream